### PR TITLE
[Attestation - Manager] Update flow to detect Pod-crash and reboot of…

### DIFF
--- a/attestation-manager/src/pkg/constants/config.go
+++ b/attestation-manager/src/pkg/constants/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	NodeAgentCertPath               string
 	CMSCertPath                     string
 	OrchestratorCertPath            string
+	FlavorUpdateFilePath            string
 	AttestationManagerServerAddress string
 	AttestationManagerServerPort    string
 	TCHOSTNAME                      string
@@ -41,6 +42,7 @@ func LoadConfig() (*Config, error) {
 		NodeAgentCertPath:    "/mnt/access_token",
 		CMSCertPath:          "/mnt/cms-ca-cert.pem",
 		OrchestratorCertPath: "/mnt/orch-ca.crt",
+		FlavorUpdateFilePath: "/temp/attestation_mgr/flavor_update",
 	}
 
 	// Map environment variables to config fields

--- a/helm/attestation-manager/templates/deployment.yaml
+++ b/helm/attestation-manager/templates/deployment.yaml
@@ -107,6 +107,8 @@ spec:
             - name: ca-certificates
               mountPath: "/mnt/orch-ca.crt"
               readOnly: true
+            - name: flavor_addition_check
+              mountPath: /temp/attestation_mgr/
       volumes:
         - name: attestation-manager-token
           hostPath:
@@ -114,6 +116,10 @@ spec:
         - name: ca-certificates
           hostPath:
             path: /etc/intel_edge_node/orch-ca-cert/orch-ca.crt
+        - name: flavor_addition_check
+          hostPath:
+            path: /tmp/attestation_manager/
+            type: DirectoryOrCreate
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
… EN for flavor template addition

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [Y ] The changes in the PR have been built and tested
- [ Y] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->

Fixes # (issue)
Attestation Manager to identify to differentiate between pod crash Vs system reboot

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Case1: TC deployed freshly

AM should create flavors and host registration
It should mark in a file
Case2: Am restarts again for some reason/crash

AM should not create flavors again
It should create only trust reports
Case 3: AM reboots again due to time outs

AM should not create flavors if file is marked
It should create only trust reports
Case 4: System reboot

AM should create flavors and host registration
It should mark in a file
 
case 5: uninstalling and reinstallation of AM (testing pending)
Verifier cleanup should delete the /tmp/attestation_manager/dir on EN

Approach:
mount /tmp/attest-manage folder to AM mod
Create attest-manager-don in /tmp/attest-manager once flavors gets created.
At reboot, /tmp/attest-manage folder should not be there

