### PR TITLE
docker supoort for standalone release

### DIFF
--- a/baremetal/Makefile
+++ b/baremetal/Makefile
@@ -66,8 +66,8 @@ build:
 	yq -i '(select(.kind == "HelmChart" and .metadata.name == "kata-deploy").spec.valuesContent) = load_str("'"$$KATA_DEPLOY_VALUES_FILE"'")' "$$STAGEDIR/manifests/trusted-compute.yaml"
 	rm -f "$$KATA_DEPLOY_VALUES_FILE"
 
-	# Update kata-deploy image tag in the trusted-compute.yaml manifest to match KATA_DEPLOY_VERSION
-	sed -i 's|\(tag: "\)[^"]*\("\)|\1$(KATA_DEPLOY_VERSION)\2|g' "$$STAGEDIR/manifests/trusted-compute.yaml"
+	# Update only the kata-deploy HelmChart valuesContent image tag to match KATA_DEPLOY_VERSION
+	yq -i '(select(.kind == "HelmChart" and .metadata.name == "kata-deploy").spec.valuesContent) |= sub("(?m)^([[:space:]]*tag: \")[^\"]*(\")$$"; "$${1}$(KATA_DEPLOY_VERSION)$${2}")' "$$STAGEDIR/manifests/trusted-compute.yaml"
 
 	cp -a "$(CURDIR)/config-v3.toml.tmpl" "$$STAGEDIR/containerd/config-v3.toml.tmpl"
 

--- a/baremetal/Makefile
+++ b/baremetal/Makefile
@@ -44,14 +44,18 @@ build:
 
 	# Copy existing files from repo
 	cp -a "$(CURDIR)/install.sh" "$$STAGEDIR/"
+	cp -a "$(CURDIR)/uninstall.sh" "$$STAGEDIR/"
 	cp -a "$(CURDIR)/k3s.sh" "$$STAGEDIR/k3s/k3s.sh"
 	cp -a "$(CURDIR)/trusted-compute.yaml" "$$STAGEDIR/manifests/trusted-compute.yaml"
+
+	# Create docker directory and copy tw-docker-deploy.yaml, updating image and version
+	mkdir -p "$$STAGEDIR/docker"
+	cp -a "$(CURDIR)/tw-docker-deploy.yaml" "$$STAGEDIR/docker/tw-docker-deploy.yaml"
+	sed -i 's|\(kata-deploy:\).*|\1$(KATA_DEPLOY_VERSION)|g' "$$STAGEDIR/docker/tw-docker-deploy.yaml"
 
 	# Replace hardcoded chart versions in the staged manifest with Makefile vars using sed
 	sed -i \
 		-e 's/attestation-verifier\.tgz/attestation-verifier-$(ATTESTATION_VERIFIER_VERSION).tgz/g' \
-		-e 's/attestation-manager\.tgz/attestation-manager-$(ATTESTATION_MANAGER_VERSION).tgz/g' \
-		-e 's/trustagent\.tgz/trustagent-$(ATTESTATION_VERIFIER_VERSION).tgz/g' \
 		-e 's/trusted-workload\.tgz/trusted-workload-$(TRUSTED_WORKLOAD_VERSION).tgz/g' \
 		-e 's/kata-deploy\.tgz/kata-deploy-$(KATA_DEPLOY_CHART_VERSION).tgz/g' \
 		"$$STAGEDIR/manifests/trusted-compute.yaml"

--- a/baremetal/Makefile
+++ b/baremetal/Makefile
@@ -16,7 +16,7 @@ TRUSTED_WORKLOAD_VERSION         ?= $(shell cat ./../trusted-workload/VERSION)
 KATA_DEPLOY_VERSION              ?= $(shell cat ./../trusted-workload/kata-deploy/VERSION)
 KATA_DEPLOY_CHART_VERSION        ?= $(shell yq -r '."kata-containers".version' ./../trusted-workload/kata-deploy/version.yaml)
 KATA_DEPLOY_CHART_OCI            ?= oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy
-CLUSTER_EXTENSIONS_VERSION       ?= v1.5.11
+CLUSTER_EXTENSIONS_VERSION       ?= v1.6.0
 KATA_DEPLOY_VALUES_URL           ?= https://raw.githubusercontent.com/open-edge-platform/cluster-extensions/refs/tags/$(CLUSTER_EXTENSIONS_VERSION)/deployment-package/trusted-compute/values-kata-deploy-default.yaml
 
 all: 

--- a/baremetal/Makefile
+++ b/baremetal/Makefile
@@ -51,7 +51,7 @@ build:
 	# Create docker directory and copy tw-docker-deploy.yaml, updating image and version
 	mkdir -p "$$STAGEDIR/docker"
 	cp -a "$(CURDIR)/tw-docker-deploy.yaml" "$$STAGEDIR/docker/tw-docker-deploy.yaml"
-	sed -i 's|\(kata-deploy:\).*|\1$(KATA_DEPLOY_VERSION)|g' "$$STAGEDIR/docker/tw-docker-deploy.yaml"
+	sed -i 's|\(image:.*kata-deploy:\)[^[:space:]]*|\1$(KATA_DEPLOY_VERSION)|g' "$$STAGEDIR/docker/tw-docker-deploy.yaml"
 
 	# Replace hardcoded chart versions in the staged manifest with Makefile vars using sed
 	sed -i \

--- a/baremetal/Makefile
+++ b/baremetal/Makefile
@@ -66,6 +66,9 @@ build:
 	yq -i '(select(.kind == "HelmChart" and .metadata.name == "kata-deploy").spec.valuesContent) = load_str("'"$$KATA_DEPLOY_VALUES_FILE"'")' "$$STAGEDIR/manifests/trusted-compute.yaml"
 	rm -f "$$KATA_DEPLOY_VALUES_FILE"
 
+	# Update kata-deploy image tag in the trusted-compute.yaml manifest to match KATA_DEPLOY_VERSION
+	sed -i 's|\(tag: "\)[^"]*\("\)|\1$(KATA_DEPLOY_VERSION)\2|g' "$$STAGEDIR/manifests/trusted-compute.yaml"
+
 	cp -a "$(CURDIR)/config-v3.toml.tmpl" "$$STAGEDIR/containerd/config-v3.toml.tmpl"
 
 	# Readme points to docs/trusted_compute_baremetal.md

--- a/baremetal/install.sh
+++ b/baremetal/install.sh
@@ -239,8 +239,8 @@ print_tc_docker_summary() {
 
 # Check if Docker TC installation already exists (blocks K3s install)
 check_no_tc_docker_conflict() {
-    if command -v docker &>/dev/null && docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^kata-deploy$'; then
-        print_error "TC Docker installation is already active."
+    if command -v docker &>/dev/null && docker container inspect kata-deploy &>/dev/null 2>&1; then
+        print_error "TC Docker installation already exists (container 'kata-deploy' is present)."
         print_error "Please uninstall it first: sudo ./uninstall.sh --docker  (or run sudo ./uninstall.sh and select Docker)"
         exit 1
     fi

--- a/baremetal/install.sh
+++ b/baremetal/install.sh
@@ -2,10 +2,12 @@
 #
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
-#/
+#
 
 # Trusted Compute Installation Script
-# This script installs trusted-compute components for K3s
+# Supports two installation modes:
+#   --k3s     Install trusted-compute components for K3s
+#   --docker  Install Trusted-compute components for Docker
 # Must be run as sudo
 
 set -e  # Exit on any error
@@ -38,8 +40,18 @@ check_root() {
     fi
 }
 
-# Function to check required directories/files
-check_requirements() {
+# Shared path constants (call after SCRIPT_DIR is set)
+set_paths() {
+    K3S_CHARTS_DIR="/var/lib/rancher/k3s/server/static/charts"
+    K3S_MANIFESTS_DIR="/var/lib/rancher/k3s/server/manifests"
+    K3S_IMAGES_DIR="/var/lib/rancher/k3s/agent/images"
+    CONTAINERD_ETC_DIR="/var/lib/rancher/k3s/agent/etc/containerd"
+    CONTAINERD_CONFIG_SRC="$SCRIPT_DIR/containerd/config-v3.toml.tmpl"
+    CONTAINERD_CONFIG_DEST="$CONTAINERD_ETC_DIR/config-v3.toml.tmpl"
+}
+
+# Function to check required directories/files for TC installation for K3s
+check_requirements_k3s() {
     if [[ ! -d "$SCRIPT_DIR/charts" ]]; then
         print_error "Charts directory not found: $SCRIPT_DIR/charts"
         exit 1
@@ -138,10 +150,17 @@ restart_k3s() {
     systemctl restart k3s && print_status "Successfully restarted K3s service" || { print_error "Failed to restart K3s service"; exit 1; }
 }
 
-# Function to print summary
+# Function to check K3s service is installed and enabled
+check_k3s_service() {
+    command -v k3s &>/dev/null || { print_error "k3s is not installed or not in PATH"; exit 1; }
+    systemctl is-enabled k3s &>/dev/null || { print_error "k3s service is not enabled. Please install K3s first."; exit 1; }
+    print_status "K3s service is available."
+}
+
+# Function to print summary (TC installation for K3s)
 print_summary() {
     print_status "Installation completed successfully!"
-    print_status "Summary of installed components:"
+    print_status "Summary of installed components (TC installation for K3s):"
     echo "  - Charts copied to: $K3S_CHARTS_DIR"
     echo "  - Manifest copied to: $K3S_MANIFESTS_DIR/trusted-compute.yaml"
     echo "  - Images copied to: $K3S_IMAGES_DIR"
@@ -168,23 +187,84 @@ wait_for_namespace_ready() {
     fi
 }
 
-# Main script execution
-main() {
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    K3S_CHARTS_DIR="/var/lib/rancher/k3s/server/static/charts"
-    K3S_MANIFESTS_DIR="/var/lib/rancher/k3s/server/manifests"
-    K3S_IMAGES_DIR="/var/lib/rancher/k3s/agent/images"
-    CONTAINERD_ETC_DIR="/var/lib/rancher/k3s/agent/etc/containerd"
-    CONTAINERD_CONFIG_SRC="$SCRIPT_DIR/containerd/config-v3.toml.tmpl"
-    CONTAINERD_CONFIG_DEST="$CONTAINERD_ETC_DIR/config-v3.toml.tmpl"
-    TIMEOUT=$((20*60))
-    INTERVAL=15
+# Function to check requirements for TC installation for Docker
+check_requirements_docker() {
+    if [[ ! -d "$SCRIPT_DIR/images" ]]; then
+        print_error "Images directory not found: $SCRIPT_DIR/images"
+        exit 1
+    fi
+    if [[ ! -f "$SCRIPT_DIR/docker/tw-docker-deploy.yaml" ]]; then
+        print_error "tw-docker-deploy.yaml not found: $SCRIPT_DIR/docker/tw-docker-deploy.yaml"
+        exit 1
+    fi
+    if ! command -v docker &>/dev/null; then
+        print_error "docker is not installed or not in PATH"
+        exit 1
+    fi
+    if ! docker compose version &>/dev/null; then
+        print_error "docker compose plugin is not installed or not available"
+        exit 1
+    fi
+}
 
-    check_root
+# Function to import the kata-deploy image
+import_kata_deploy_image() {
+    print_status "Importing kata-deploy container image..."
+    local tar_file
+    tar_file=$(find "$SCRIPT_DIR/images" -maxdepth 1 -name "*kata-deploy*.tar" | head -n 1)
+    if [[ -z "$tar_file" ]]; then
+        print_error "No kata-deploy image tar found in $SCRIPT_DIR/images"
+        exit 1
+    fi
+    print_status "Loading image from: $tar_file"
+    docker load -i "$tar_file" && print_status "Successfully loaded kata-deploy image" || { print_error "Failed to load kata-deploy image"; exit 1; }
+}
+
+# Function to start the docker compose service
+start_docker_deploy() {
+    print_status "Starting kata-deploy via Docker Compose..."
+    docker compose -f "$SCRIPT_DIR/docker/tw-docker-deploy.yaml" up -d \
+        && print_status "kata-deploy container started successfully" \
+        || { print_error "Failed to start kata-deploy container"; exit 1; }
+}
+
+# Function to print summary (TC installation for Docker)
+print_summary_docker() {
+    print_status "Installation completed successfully!"
+    print_status "Summary of installed components (TC installation for Docker):"
+    echo "  - kata-deploy image loaded from: $SCRIPT_DIR/images"
+    echo "  - Docker Compose file:           $SCRIPT_DIR/docker/tw-docker-deploy.yaml"
+    echo "  - Container started:             kata-deploy"
+}
+
+# Check if Docker TC installation already exists (blocks K3s install)
+check_no_docker_conflict() {
+    if command -v docker &>/dev/null && docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^kata-deploy$'; then
+        print_error "TC Docker installation is already active."
+        print_error "Please uninstall it first: sudo ./uninstall.sh --docker  (or run sudo ./uninstall.sh and select Docker)"
+        exit 1
+    fi
+}
+
+# Check if K3s TC installation already exists (blocks Docker install)
+check_no_k3s_conflict() {
+    local found=false
+    [[ -f "$K3S_MANIFESTS_DIR/trusted-compute.yaml" ]] && found=true
+    command -v kubectl &>/dev/null && kubectl get namespace trusted-compute &>/dev/null 2>&1 && found=true
+    if [[ "$found" == true ]]; then
+        print_error "TC K3s installation is already active."
+        print_error "Please uninstall it first: sudo ./uninstall.sh --k3s  (or run sudo ./uninstall.sh and select K3s)"
+        exit 1
+    fi
+}
+
+install_k3s() {
+    check_no_docker_conflict
     check_secure_boot
+    check_k3s_service
     print_status "Installation script running from: $SCRIPT_DIR"
-    check_requirements
-    print_status "Starting trusted-compute installation..."
+    check_requirements_k3s
+    print_status "Starting TC installation for K3s..."
     create_target_dirs
     copy_charts
     copy_manifests
@@ -200,4 +280,76 @@ main() {
     wait_for_namespace_ready "trusted-compute" "$TIMEOUT"
 }
 
-main
+install_docker() {
+    check_no_k3s_conflict
+    check_secure_boot
+    print_status "Installation script running from: $SCRIPT_DIR"
+    check_requirements_docker
+    print_status "Starting TC installation for Docker..."
+    import_kata_deploy_image
+    start_docker_deploy
+    print_summary_docker
+}
+
+# interactive menu
+
+select_mode() {
+    local options=("K3s    - TC installation for K3s" "Docker - TC installation for Docker")
+    local selected=0 key k2 k3
+    local -a modes=(k3s docker)
+
+    _draw_menu() {
+        printf '\nSelect installation mode (use arrow keys, press Enter to confirm):\n\n'
+        for i in "${!options[@]}"; do
+            [[ $i -eq $selected ]] \
+                && printf "  \e[7m ${options[$i]} \e[0m\n" \
+                || printf "    ${options[$i]}\n"
+        done
+    }
+
+    tput civis; _draw_menu
+    while IFS= read -rsn1 key; do
+        [[ $key == $'\x1b' ]] && { IFS= read -rsn1 -t 0.1 k2; IFS= read -rsn1 -t 0.1 k3; key+="${k2}${k3}"; }
+        case "$key" in
+            $'\x1b[A'|$'\x1b[D') (( selected-- )) || true; (( selected < 0 )) && selected=$(( ${#options[@]} - 1 )) ;;
+            $'\x1b[B'|$'\x1b[C') (( selected++ )) || true; (( selected >= ${#options[@]} )) && selected=0 ;;
+            '') break ;;
+        esac
+        tput cuu $(( ${#options[@]} + 3 )); _draw_menu
+    done
+    tput cnorm; printf '\n'
+    INSTALL_MODE="${modes[$selected]}"
+}
+
+# Main script execution
+main() {
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    set_paths
+    TIMEOUT=$((20*60))
+    INSTALL_MODE=""
+
+    # Parse argument
+    case "${1:-}" in
+        --k3s)    INSTALL_MODE="k3s" ;;
+        --docker) INSTALL_MODE="docker" ;;
+        "")       : ;;  # will prompt below
+        *)
+            print_error "Unknown argument: $1"
+            echo "Usage: $0 [--k3s | --docker]"
+            exit 1
+            ;;
+    esac
+
+    check_root
+
+    # If no mode given, show interactive menu
+    [[ -z "$INSTALL_MODE" ]] && select_mode
+
+    case "$INSTALL_MODE" in
+        k3s)    install_k3s ;;
+        docker) install_docker ;;
+    esac
+}
+
+[[ "${1:-}" == "--source-only" ]] && return 0
+main "$@"

--- a/baremetal/install.sh
+++ b/baremetal/install.sh
@@ -5,7 +5,7 @@
 #
 
 # Trusted Compute Installation Script
-# Supports two installation modes:
+# Supports two installation options:
 #   --k3s     Install trusted-compute components for K3s
 #   --docker  Install Trusted-compute components for Docker
 # Must be run as sudo
@@ -51,7 +51,7 @@ set_paths() {
 }
 
 # Function to check required directories/files for TC installation for K3s
-check_requirements_k3s() {
+check_tc_requirements_k3s() {
     if [[ ! -d "$SCRIPT_DIR/charts" ]]; then
         print_error "Charts directory not found: $SCRIPT_DIR/charts"
         exit 1
@@ -158,7 +158,7 @@ check_k3s_service() {
 }
 
 # Function to print summary (TC installation for K3s)
-print_summary() {
+print_tc_k3s_summary() {
     print_status "Installation completed successfully!"
     print_status "Summary of installed components (TC installation for K3s):"
     echo "  - Charts copied to: $K3S_CHARTS_DIR"
@@ -188,7 +188,7 @@ wait_for_namespace_ready() {
 }
 
 # Function to check requirements for TC installation for Docker
-check_requirements_docker() {
+check_tc_requirements_docker() {
     if [[ ! -d "$SCRIPT_DIR/images" ]]; then
         print_error "Images directory not found: $SCRIPT_DIR/images"
         exit 1
@@ -229,7 +229,7 @@ start_docker_deploy() {
 }
 
 # Function to print summary (TC installation for Docker)
-print_summary_docker() {
+print_tc_docker_summary() {
     print_status "Installation completed successfully!"
     print_status "Summary of installed components (TC installation for Docker):"
     echo "  - kata-deploy image loaded from: $SCRIPT_DIR/images"
@@ -238,7 +238,7 @@ print_summary_docker() {
 }
 
 # Check if Docker TC installation already exists (blocks K3s install)
-check_no_docker_conflict() {
+check_no_tc_docker_conflict() {
     if command -v docker &>/dev/null && docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^kata-deploy$'; then
         print_error "TC Docker installation is already active."
         print_error "Please uninstall it first: sudo ./uninstall.sh --docker  (or run sudo ./uninstall.sh and select Docker)"
@@ -247,7 +247,7 @@ check_no_docker_conflict() {
 }
 
 # Check if K3s TC installation already exists (blocks Docker install)
-check_no_k3s_conflict() {
+check_no_tc_k3s_conflict() {
     local found=false
     [[ -f "$K3S_MANIFESTS_DIR/trusted-compute.yaml" ]] && found=true
     command -v kubectl &>/dev/null && kubectl get namespace trusted-compute &>/dev/null 2>&1 && found=true
@@ -258,12 +258,12 @@ check_no_k3s_conflict() {
     fi
 }
 
-install_k3s() {
-    check_no_docker_conflict
+install_tc_k3s() {
+    check_no_tc_docker_conflict
     check_secure_boot
     check_k3s_service
     print_status "Installation script running from: $SCRIPT_DIR"
-    check_requirements_k3s
+    check_tc_requirements_k3s
     print_status "Starting TC installation for K3s..."
     create_target_dirs
     copy_charts
@@ -273,33 +273,33 @@ install_k3s() {
     set_permissions
     create_users_groups
     restart_k3s
-    print_summary
+    print_tc_k3s_summary
     print_status "Wait for daemonsets and deployments to become ready..."
     sleep 180
     wait_for_namespace_ready "confidential-containers-system" "$TIMEOUT"
     wait_for_namespace_ready "trusted-compute" "$TIMEOUT"
 }
 
-install_docker() {
-    check_no_k3s_conflict
+install_tc_docker() {
+    check_no_tc_k3s_conflict
     check_secure_boot
     print_status "Installation script running from: $SCRIPT_DIR"
-    check_requirements_docker
+    check_tc_requirements_docker
     print_status "Starting TC installation for Docker..."
     import_kata_deploy_image
     start_docker_deploy
-    print_summary_docker
+    print_tc_docker_summary
 }
 
 # interactive menu
 
-select_mode() {
+select_deployment_option() {
     local options=("K3s    - TC installation for K3s" "Docker - TC installation for Docker")
     local selected=0 key k2 k3
     local -a modes=(k3s docker)
 
     _draw_menu() {
-        printf '\nSelect installation mode (use arrow keys, press Enter to confirm):\n\n'
+        printf '\nSelect installation option (use arrow keys, press Enter to confirm):\n\n'
         for i in "${!options[@]}"; do
             [[ $i -eq $selected ]] \
                 && printf "  \e[7m ${options[$i]} \e[0m\n" \
@@ -318,7 +318,7 @@ select_mode() {
         tput cuu $(( ${#options[@]} + 3 )); _draw_menu
     done
     tput cnorm; printf '\n'
-    INSTALL_MODE="${modes[$selected]}"
+    DEPLOYMENT_OPTION="${modes[$selected]}"
 }
 
 # Main script execution
@@ -326,12 +326,12 @@ main() {
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     set_paths
     TIMEOUT=$((20*60))
-    INSTALL_MODE=""
+    DEPLOYMENT_OPTION=""
 
     # Parse argument
     case "${1:-}" in
-        --k3s)    INSTALL_MODE="k3s" ;;
-        --docker) INSTALL_MODE="docker" ;;
+        --k3s)    DEPLOYMENT_OPTION="k3s" ;;
+        --docker) DEPLOYMENT_OPTION="docker" ;;
         "")       : ;;  # will prompt below
         *)
             print_error "Unknown argument: $1"
@@ -342,12 +342,12 @@ main() {
 
     check_root
 
-    # If no mode given, show interactive menu
-    [[ -z "$INSTALL_MODE" ]] && select_mode
+    # If no option given, show interactive menu
+    [[ -z "$DEPLOYMENT_OPTION" ]] && select_deployment_option
 
-    case "$INSTALL_MODE" in
-        k3s)    install_k3s ;;
-        docker) install_docker ;;
+    case "$DEPLOYMENT_OPTION" in
+        k3s)    install_tc_k3s ;;
+        docker) install_tc_docker ;;
     esac
 }
 

--- a/baremetal/install.sh
+++ b/baremetal/install.sh
@@ -276,7 +276,6 @@ install_tc_k3s() {
     print_tc_k3s_summary
     print_status "Wait for daemonsets and deployments to become ready..."
     sleep 180
-    wait_for_namespace_ready "confidential-containers-system" "$TIMEOUT"
     wait_for_namespace_ready "trusted-compute" "$TIMEOUT"
 }
 

--- a/baremetal/tw-docker-deploy.yaml
+++ b/baremetal/tw-docker-deploy.yaml
@@ -1,0 +1,14 @@
+services:
+  kata-deploy:
+    image: registry-rs.edgeorchestration.intel.com/edge-orch/trusted-compute/kata-deploy:${VERSION}
+    container_name: kata-deploy
+    privileged: true
+    entrypoint: ["/opt/kata-artifacts/opt/kata/bin/tc-docker-deploy"]
+    volumes:
+      - /opt:/host/opt
+      - /usr/bin:/host/usr/bin
+      - /etc:/host/etc
+    environment:
+      - DEBUG=false
+    restart: unless-stopped
+    network_mode: none

--- a/baremetal/uninstall.sh
+++ b/baremetal/uninstall.sh
@@ -16,7 +16,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 [[ -f "$SCRIPT_DIR/install.sh" ]] || { echo "[ERROR] install.sh not found in $SCRIPT_DIR" >&2; exit 1; }
 source "$SCRIPT_DIR/install.sh" --source-only
 
-# Function to remove the manifest (triggers K3s to uninstall HelmCharts)
+# Function to remove the manifest
 remove_tc_manifest() {
     print_status "Removing trusted-compute manifest from $K3S_MANIFESTS_DIR..."
     if [[ -f "$K3S_MANIFESTS_DIR/trusted-compute.yaml" ]]; then
@@ -28,21 +28,75 @@ remove_tc_manifest() {
     fi
 }
 
-# Function to wait for namespaces to be cleaned up
-wait_for_namespace_deleted() {
-    local ns="$1"
-    local timeout="$2"
-    print_status "Waiting for namespace '$ns' to be deleted (timeout: ${timeout}s)..."
+# Function to wait for a Kubernetes resource to be deleted
+# Usage: wait_for_resource_deleted <resource_type> <resource_name> <namespace> <max_wait_seconds> <check_interval>
+wait_for_resource_deleted() {
+    local resource_type="$1"
+    local resource_name="$2"
+    local namespace="$3"
+    local max_wait="${4:-60}"
+    local check_interval="${5:-3}"
+
     local elapsed=0
-    while kubectl get namespace "$ns" &>/dev/null; do
-        if [[ $elapsed -ge $timeout ]]; then
-            print_warning "Timeout: namespace '$ns' was not deleted after ${timeout} seconds. Continuing..."
-            return
+    local namespace_flag=""
+    [[ -n "$namespace" ]] && namespace_flag="-n $namespace"
+
+    while kubectl get "$resource_type" "$resource_name" $namespace_flag &>/dev/null && [[ $elapsed -lt $max_wait ]]; do
+        sleep "$check_interval"
+        elapsed=$((elapsed + check_interval))
+        if [[ $((elapsed % 15)) -eq 0 ]]; then
+            print_status "Waiting for $resource_type '$resource_name' to be removed... (${elapsed}s)"
         fi
-        sleep 15
-        elapsed=$((elapsed + 15))
     done
-    print_status "Namespace '$ns' has been deleted."
+
+    if kubectl get "$resource_type" "$resource_name" $namespace_flag &>/dev/null; then
+        print_warning "$resource_type '$resource_name' still exists after ${max_wait}s, continuing..."
+        return 1
+    else
+        print_status "$resource_type '$resource_name' fully removed"
+        return 0
+    fi
+}
+
+# Function to delete Kubernetes resources explicitly
+delete_tc_k8s_resources() {
+    print_status "Deleting Kubernetes resources explicitly..."
+
+    # Delete AddOn resource
+    if kubectl get addon trusted-compute -n kube-system &>/dev/null; then
+        kubectl delete addon trusted-compute -n kube-system --timeout=60s \
+            && print_status "Deleted AddOn: trusted-compute" \
+            || print_warning "Failed to delete AddOn: trusted-compute"
+        wait_for_resource_deleted "addon" "trusted-compute" "kube-system" 60 3
+    else
+        print_warning "AddOn 'trusted-compute' not found, skipping"
+    fi
+
+    # Delete HelmChart resources
+    for chart in kata-deploy attestation-verifier trusted-workload; do
+        if kubectl get helmchart "$chart" -n kube-system &>/dev/null; then
+            local timeout=60
+            [[ "$chart" == "attestation-verifier" ]] && timeout=120
+            kubectl delete helmchart "$chart" -n kube-system --timeout=${timeout}s \
+                && print_status "Deleted HelmChart: $chart" \
+                || print_warning "Failed to delete HelmChart: $chart"
+            wait_for_resource_deleted "helmchart" "$chart" "kube-system" "$timeout" 3
+        else
+            print_warning "HelmChart '$chart' not found, skipping"
+        fi
+    done
+
+    # Delete namespaces
+    for ns in trusted-compute kata-deploy; do
+        if kubectl get namespace "$ns" &>/dev/null; then
+            kubectl delete namespace "$ns" --timeout=60s \
+                && print_status "Deleted namespace: $ns" \
+                || print_warning "Failed to delete namespace: $ns"
+            wait_for_resource_deleted "namespace" "$ns" "" 120 5
+        else
+            print_warning "Namespace '$ns' not found, skipping"
+        fi
+    done
 }
 
 # Function to remove Helm charts
@@ -60,7 +114,7 @@ remove_tc_charts() {
 # Function to remove container images
 remove_tc_images() {
     print_status "Removing container images from $K3S_IMAGES_DIR..."
-    for img in attestation-manager attestation-verifier kata-deploy trusted-workload; do
+    for img in attestation-manager attestation-verifier kata-deploy; do
         local found
         found=$(find "$K3S_IMAGES_DIR" -maxdepth 1 -name "*${img}*.tar" 2>/dev/null)
         if [[ -n "$found" ]]; then
@@ -122,10 +176,12 @@ print_tc_k3s_uninstall_summary() {
     print_status "Uninstallation completed."
     print_status "Summary of removed components (TC uninstallation for K3s):"
     echo "  - Manifest removed from: $K3S_MANIFESTS_DIR"
+    echo "  - K3s resources deleted: AddOn, HelmCharts Namespaces"
+    echo "  - K3s service:           Restarted"
     echo "  - Charts removed from:   $K3S_CHARTS_DIR"
     echo "  - Images removed from:   $K3S_IMAGES_DIR"
     echo "  - Containerd config:     $CONTAINERD_CONFIG_DEST"
-    echo "  - Users/groups:          tc-agent, tc-ima, bm-agents"
+    echo "  - Users/groups removed:  tc-agent, tc-ima, bm-agents"
 }
 
 # Function to print uninstall summary (Docker)
@@ -167,10 +223,8 @@ uninstall_tc_k3s() {
     check_tc_k3s_installed
     print_status "Starting TC uninstallation for K3s..."
     remove_tc_manifest
+    delete_tc_k8s_resources
     restart_k3s
-    print_status "Waiting for HelmChart resources to be cleaned up..."
-    wait_for_namespace_deleted "trusted-compute" "$TIMEOUT"
-    wait_for_namespace_deleted "kata-deploy" "$TIMEOUT"
     remove_tc_charts
     remove_tc_images
     remove_tc_containerd_config
@@ -217,7 +271,6 @@ select_uninstall_option() {
 # Main script execution
 main() {
     set_paths
-    TIMEOUT=$((10*60))
     DEPLOYMENT_OPTION=""
 
     # Parse argument (reuse same flags as install.sh)

--- a/baremetal/uninstall.sh
+++ b/baremetal/uninstall.sh
@@ -224,11 +224,11 @@ uninstall_tc_k3s() {
     print_status "Starting TC uninstallation for K3s..."
     remove_tc_manifest
     delete_tc_k8s_resources
-    restart_k3s
     remove_tc_charts
     remove_tc_images
     remove_tc_containerd_config
     remove_tc_users_groups
+    restart_k3s
     print_tc_k3s_uninstall_summary
 }
 

--- a/baremetal/uninstall.sh
+++ b/baremetal/uninstall.sh
@@ -1,0 +1,245 @@
+#!/bin/bash
+#
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# Trusted Compute Uninstallation Script
+# This script uninstalls trusted-compute components from K3s/Docker
+# Must be run as sudo
+
+set -e  # Exit on any error
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Load common functions and variables from install.sh
+[[ -f "$SCRIPT_DIR/install.sh" ]] || { echo "[ERROR] install.sh not found in $SCRIPT_DIR" >&2; exit 1; }
+source "$SCRIPT_DIR/install.sh" --source-only
+
+# Function to remove the manifest (triggers K3s to uninstall HelmCharts)
+remove_manifest() {
+    print_status "Removing trusted-compute manifest from $K3S_MANIFESTS_DIR..."
+    if [[ -f "$K3S_MANIFESTS_DIR/trusted-compute.yaml" ]]; then
+        rm -f "$K3S_MANIFESTS_DIR/trusted-compute.yaml" \
+            && print_status "Removed trusted-compute.yaml" \
+            || { print_warning "Failed to remove trusted-compute.yaml"; }
+    else
+        print_warning "Manifest not found, skipping: $K3S_MANIFESTS_DIR/trusted-compute.yaml"
+    fi
+}
+
+# Function to wait for namespaces to be cleaned up
+wait_for_namespace_deleted() {
+    local ns="$1"
+    local timeout="$2"
+    print_status "Waiting for namespace '$ns' to be deleted (timeout: ${timeout}s)..."
+    local elapsed=0
+    while kubectl get namespace "$ns" &>/dev/null; do
+        if [[ $elapsed -ge $timeout ]]; then
+            print_warning "Timeout: namespace '$ns' was not deleted after ${timeout} seconds. Continuing..."
+            return
+        fi
+        sleep 15
+        elapsed=$((elapsed + 15))
+    done
+    print_status "Namespace '$ns' has been deleted."
+}
+
+# Function to remove Helm charts
+remove_charts() {
+    print_status "Removing Helm charts from $K3S_CHARTS_DIR..."
+    for chart in attestation-verifier trusted-workload kata-deploy; do
+        if rm -f "$K3S_CHARTS_DIR/${chart}"*.tgz 2>/dev/null; then
+            print_status "Removed ${chart} chart(s)"
+        else
+            print_warning "No ${chart} chart found to remove"
+        fi
+    done
+}
+
+# Function to remove container images
+remove_images() {
+    print_status "Removing container images from $K3S_IMAGES_DIR..."
+    for img in attestation-manager attestation-verifier kata-deploy trusted-workload; do
+        local found
+        found=$(find "$K3S_IMAGES_DIR" -maxdepth 1 -name "*${img}*.tar" 2>/dev/null)
+        if [[ -n "$found" ]]; then
+            echo "$found" | xargs rm -f
+            print_status "Removed image tar(s) matching: ${img}"
+        else
+            print_warning "No image tar found matching: ${img}, skipping"
+        fi
+    done
+}
+
+# Function to remove containerd config
+remove_containerd_config() {
+    print_status "Removing containerd config template..."
+    if [[ -f "$CONTAINERD_CONFIG_DEST" ]]; then
+        rm -f "$CONTAINERD_CONFIG_DEST" \
+            && print_status "Removed containerd config: $CONTAINERD_CONFIG_DEST" \
+            || print_warning "Failed to remove containerd config"
+    else
+        print_warning "Containerd config not found, skipping: $CONTAINERD_CONFIG_DEST"
+    fi
+}
+
+# Function to stop docker deploy container
+stop_docker_deploy() {
+    local compose_file="$SCRIPT_DIR/docker/tw-docker-deploy.yaml"
+    print_status "Stopping kata-deploy ..."
+    if [[ ! -f "$compose_file" ]]; then
+        print_warning "Compose file not found, skipping: $compose_file"
+        return
+    fi
+    docker compose -f "$compose_file" down \
+        && print_status "kata-deploy stopped and removed successfully" \
+        || print_warning "Failed to stop kata-deploy via docker compose"
+}
+
+# Function to remove users/groups
+remove_users_groups() {
+    print_status "Removing trusted compute users and groups..."
+    if id -u tc-agent &>/dev/null; then
+        userdel tc-agent && print_status "Removed tc-agent user" || print_warning "Failed to remove tc-agent user"
+    else
+        print_warning "tc-agent user not found, skipping"
+    fi
+    if id -u tc-ima &>/dev/null; then
+        userdel tc-ima && print_status "Removed tc-ima user" || print_warning "Failed to remove tc-ima user"
+    else
+        print_warning "tc-ima user not found, skipping"
+    fi
+    if getent group bm-agents &>/dev/null; then
+        groupdel bm-agents && print_status "Removed bm-agents group" || print_warning "Failed to remove bm-agents group"
+    else
+        print_warning "bm-agents group not found, skipping"
+    fi
+}
+
+# Function to print uninstall summary (K3s)
+print_summary_k3s() {
+    print_status "Uninstallation completed."
+    print_status "Summary of removed components (TC uninstallation for K3s):"
+    echo "  - Manifest removed from: $K3S_MANIFESTS_DIR"
+    echo "  - Charts removed from:   $K3S_CHARTS_DIR"
+    echo "  - Images removed from:   $K3S_IMAGES_DIR"
+    echo "  - Containerd config:     $CONTAINERD_CONFIG_DEST"
+    echo "  - Users/groups:          tc-agent, tc-ima, bm-agents"
+}
+
+# Function to print uninstall summary (Docker)
+print_summary_docker() {
+    print_status "Uninstallation completed."
+    print_status "Summary of removed components (TC uninstallation for Docker):"
+    echo "  - kata-deploy container stopped and removed"
+}
+
+# Pre-flight check for K3s installation
+check_k3s_installed() {
+    print_status "Checking if TC is installed for K3s..."
+    local found=false
+    [[ -f "$K3S_MANIFESTS_DIR/trusted-compute.yaml" ]] && found=true
+    [[ -n "$(ls "$K3S_CHARTS_DIR"/attestation-verifier*.tgz "$K3S_CHARTS_DIR"/kata-deploy*.tgz 2>/dev/null)" ]] && found=true
+    command -v kubectl &>/dev/null && kubectl get namespace trusted-compute &>/dev/null && found=true
+    if [[ "$found" == false ]]; then
+        print_error "TC K3s installation not detected (manifest, charts, and namespace not found). Nothing to uninstall."
+        exit 1
+    fi
+    print_status "TC K3s installation detected."
+}
+
+# Pre-flight check for Docker installation
+check_docker_installed() {
+    print_status "Checking if TC is installed for Docker..."
+    if ! command -v docker &>/dev/null; then
+        print_error "docker is not installed or not in PATH"
+        exit 1
+    fi
+    if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^kata-deploy$'; then
+        print_error "kata-deploy container is not running. TC Docker installation not detected. Nothing to uninstall."
+        exit 1
+    fi
+    print_status "kata-deploy container is running."
+}
+
+uninstall_k3s() {
+    check_k3s_installed
+    print_status "Starting TC uninstallation for K3s..."
+    remove_manifest
+    restart_k3s
+    print_status "Waiting for HelmChart resources to be cleaned up..."
+    wait_for_namespace_deleted "trusted-compute" "$TIMEOUT"
+    wait_for_namespace_deleted "kata-deploy" "$TIMEOUT"
+    wait_for_namespace_deleted "confidential-containers-system" "$TIMEOUT"
+    remove_charts
+    remove_images
+    remove_containerd_config
+    remove_users_groups
+    print_summary_k3s
+}
+
+uninstall_docker() {
+    check_docker_installed
+    print_status "Starting TC uninstallation for Docker..."
+    stop_docker_deploy
+    print_summary_docker
+}
+
+# Interactive mode selector for uninstall
+select_uninstall_mode() {
+    local options=("K3s    - TC uninstallation for K3s" "Docker - TC uninstallation for Docker")
+    local selected=0 key k2 k3
+    local -a modes=(k3s docker)
+
+    _draw_menu() {
+        printf '\nSelect uninstallation mode (use arrow keys, press Enter to confirm):\n\n'
+        for i in "${!options[@]}"; do
+            [[ $i -eq $selected ]] \
+                && printf "  \e[7m ${options[$i]} \e[0m\n" \
+                || printf "    ${options[$i]}\n"
+        done
+    }
+
+    tput civis; _draw_menu
+    while IFS= read -rsn1 key; do
+        [[ $key == $'\x1b' ]] && { IFS= read -rsn1 -t 0.1 k2; IFS= read -rsn1 -t 0.1 k3; key+="${k2}${k3}"; }
+        case "$key" in
+            $'\x1b[A'|$'\x1b[D') (( selected-- )) || true; (( selected < 0 )) && selected=$(( ${#options[@]} - 1 )) ;;
+            $'\x1b[B'|$'\x1b[C') (( selected++ )) || true; (( selected >= ${#options[@]} )) && selected=0 ;;
+            '') break ;;
+        esac
+        tput cuu $(( ${#options[@]} + 3 )); _draw_menu
+    done
+    tput cnorm; printf '\n'
+    INSTALL_MODE="${modes[$selected]}"
+}
+
+# Main script execution
+main() {
+    set_paths
+    TIMEOUT=$((10*60))
+    INSTALL_MODE=""
+
+    # Parse argument (reuse same flags as install.sh)
+    case "${1:-}" in
+        --k3s)    INSTALL_MODE="k3s" ;;
+        --docker) INSTALL_MODE="docker" ;;
+        "")       : ;;
+        *)
+            print_error "Unknown argument: $1"
+            echo "Usage: $0 [--k3s | --docker]"
+            exit 1
+            ;;
+    esac
+
+    check_root
+    [[ -z "$INSTALL_MODE" ]] && select_uninstall_mode
+
+    case "$INSTALL_MODE" in
+        k3s)    uninstall_k3s ;;
+        docker) uninstall_docker ;;
+    esac
+}
+
+main "$@"

--- a/baremetal/uninstall.sh
+++ b/baremetal/uninstall.sh
@@ -17,7 +17,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/install.sh" --source-only
 
 # Function to remove the manifest (triggers K3s to uninstall HelmCharts)
-remove_manifest() {
+remove_tc_manifest() {
     print_status "Removing trusted-compute manifest from $K3S_MANIFESTS_DIR..."
     if [[ -f "$K3S_MANIFESTS_DIR/trusted-compute.yaml" ]]; then
         rm -f "$K3S_MANIFESTS_DIR/trusted-compute.yaml" \
@@ -46,7 +46,7 @@ wait_for_namespace_deleted() {
 }
 
 # Function to remove Helm charts
-remove_charts() {
+remove_tc_charts() {
     print_status "Removing Helm charts from $K3S_CHARTS_DIR..."
     for chart in attestation-verifier trusted-workload kata-deploy; do
         if rm -f "$K3S_CHARTS_DIR/${chart}"*.tgz 2>/dev/null; then
@@ -58,7 +58,7 @@ remove_charts() {
 }
 
 # Function to remove container images
-remove_images() {
+remove_tc_images() {
     print_status "Removing container images from $K3S_IMAGES_DIR..."
     for img in attestation-manager attestation-verifier kata-deploy trusted-workload; do
         local found
@@ -73,7 +73,7 @@ remove_images() {
 }
 
 # Function to remove containerd config
-remove_containerd_config() {
+remove_tc_containerd_config() {
     print_status "Removing containerd config template..."
     if [[ -f "$CONTAINERD_CONFIG_DEST" ]]; then
         rm -f "$CONTAINERD_CONFIG_DEST" \
@@ -85,7 +85,7 @@ remove_containerd_config() {
 }
 
 # Function to stop docker deploy container
-stop_docker_deploy() {
+stop_tc_docker_deploy() {
     local compose_file="$SCRIPT_DIR/docker/tw-docker-deploy.yaml"
     print_status "Stopping kata-deploy ..."
     if [[ ! -f "$compose_file" ]]; then
@@ -98,7 +98,7 @@ stop_docker_deploy() {
 }
 
 # Function to remove users/groups
-remove_users_groups() {
+remove_tc_users_groups() {
     print_status "Removing trusted compute users and groups..."
     if id -u tc-agent &>/dev/null; then
         userdel tc-agent && print_status "Removed tc-agent user" || print_warning "Failed to remove tc-agent user"
@@ -118,7 +118,7 @@ remove_users_groups() {
 }
 
 # Function to print uninstall summary (K3s)
-print_summary_k3s() {
+print_tc_k3s_uninstall_summary() {
     print_status "Uninstallation completed."
     print_status "Summary of removed components (TC uninstallation for K3s):"
     echo "  - Manifest removed from: $K3S_MANIFESTS_DIR"
@@ -129,14 +129,14 @@ print_summary_k3s() {
 }
 
 # Function to print uninstall summary (Docker)
-print_summary_docker() {
+print_tc_docker_uninstall_summary() {
     print_status "Uninstallation completed."
     print_status "Summary of removed components (TC uninstallation for Docker):"
     echo "  - kata-deploy container stopped and removed"
 }
 
 # Pre-flight check for K3s installation
-check_k3s_installed() {
+check_tc_k3s_installed() {
     print_status "Checking if TC is installed for K3s..."
     local found=false
     [[ -f "$K3S_MANIFESTS_DIR/trusted-compute.yaml" ]] && found=true
@@ -150,7 +150,7 @@ check_k3s_installed() {
 }
 
 # Pre-flight check for Docker installation
-check_docker_installed() {
+check_tc_docker_installed() {
     print_status "Checking if TC is installed for Docker..."
     if ! command -v docker &>/dev/null; then
         print_error "docker is not installed or not in PATH"
@@ -163,37 +163,37 @@ check_docker_installed() {
     print_status "kata-deploy container is running."
 }
 
-uninstall_k3s() {
-    check_k3s_installed
+uninstall_tc_k3s() {
+    check_tc_k3s_installed
     print_status "Starting TC uninstallation for K3s..."
-    remove_manifest
+    remove_tc_manifest
     restart_k3s
     print_status "Waiting for HelmChart resources to be cleaned up..."
     wait_for_namespace_deleted "trusted-compute" "$TIMEOUT"
     wait_for_namespace_deleted "kata-deploy" "$TIMEOUT"
     wait_for_namespace_deleted "confidential-containers-system" "$TIMEOUT"
-    remove_charts
-    remove_images
-    remove_containerd_config
-    remove_users_groups
-    print_summary_k3s
+    remove_tc_charts
+    remove_tc_images
+    remove_tc_containerd_config
+    remove_tc_users_groups
+    print_tc_k3s_uninstall_summary
 }
 
-uninstall_docker() {
-    check_docker_installed
+uninstall_tc_docker() {
+    check_tc_docker_installed
     print_status "Starting TC uninstallation for Docker..."
-    stop_docker_deploy
-    print_summary_docker
+    stop_tc_docker_deploy
+    print_tc_docker_uninstall_summary
 }
 
-# Interactive mode selector for uninstall
-select_uninstall_mode() {
+# Interactive option selector for uninstall
+select_uninstall_option() {
     local options=("K3s    - TC uninstallation for K3s" "Docker - TC uninstallation for Docker")
     local selected=0 key k2 k3
     local -a modes=(k3s docker)
 
     _draw_menu() {
-        printf '\nSelect uninstallation mode (use arrow keys, press Enter to confirm):\n\n'
+        printf '\nSelect uninstallation option (use arrow keys, press Enter to confirm):\n\n'
         for i in "${!options[@]}"; do
             [[ $i -eq $selected ]] \
                 && printf "  \e[7m ${options[$i]} \e[0m\n" \
@@ -212,19 +212,19 @@ select_uninstall_mode() {
         tput cuu $(( ${#options[@]} + 3 )); _draw_menu
     done
     tput cnorm; printf '\n'
-    INSTALL_MODE="${modes[$selected]}"
+    DEPLOYMENT_OPTION="${modes[$selected]}"
 }
 
 # Main script execution
 main() {
     set_paths
     TIMEOUT=$((10*60))
-    INSTALL_MODE=""
+    DEPLOYMENT_OPTION=""
 
     # Parse argument (reuse same flags as install.sh)
     case "${1:-}" in
-        --k3s)    INSTALL_MODE="k3s" ;;
-        --docker) INSTALL_MODE="docker" ;;
+        --k3s)    DEPLOYMENT_OPTION="k3s" ;;
+        --docker) DEPLOYMENT_OPTION="docker" ;;
         "")       : ;;
         *)
             print_error "Unknown argument: $1"
@@ -234,11 +234,11 @@ main() {
     esac
 
     check_root
-    [[ -z "$INSTALL_MODE" ]] && select_uninstall_mode
+    [[ -z "$DEPLOYMENT_OPTION" ]] && select_uninstall_option
 
-    case "$INSTALL_MODE" in
-        k3s)    uninstall_k3s ;;
-        docker) uninstall_docker ;;
+    case "$DEPLOYMENT_OPTION" in
+        k3s)    uninstall_tc_k3s ;;
+        docker) uninstall_tc_docker ;;
     esac
 }
 

--- a/baremetal/uninstall.sh
+++ b/baremetal/uninstall.sh
@@ -171,7 +171,6 @@ uninstall_tc_k3s() {
     print_status "Waiting for HelmChart resources to be cleaned up..."
     wait_for_namespace_deleted "trusted-compute" "$TIMEOUT"
     wait_for_namespace_deleted "kata-deploy" "$TIMEOUT"
-    wait_for_namespace_deleted "confidential-containers-system" "$TIMEOUT"
     remove_tc_charts
     remove_tc_images
     remove_tc_containerd_config

--- a/baremetal/uninstall.sh
+++ b/baremetal/uninstall.sh
@@ -212,11 +212,11 @@ check_tc_docker_installed() {
         print_error "docker is not installed or not in PATH"
         exit 1
     fi
-    if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^kata-deploy$'; then
-        print_error "kata-deploy container is not running. TC Docker installation not detected. Nothing to uninstall."
+    if ! docker ps -a --format '{{.Names}}' 2>/dev/null | grep -q '^kata-deploy$'; then
+        print_error "kata-deploy container not found. TC Docker installation not detected. Nothing to uninstall."
         exit 1
     fi
-    print_status "kata-deploy container is running."
+    print_status "kata-deploy container detected."
 }
 
 uninstall_tc_k3s() {

--- a/docs/trusted_compute_baremetal.md
+++ b/docs/trusted_compute_baremetal.md
@@ -1,6 +1,32 @@
-## Trusted Compute k3s Installation on Standalone Ubuntu Edge Node
+## Trusted Compute Installation on Standalone Ubuntu Edge Node
 
-### Prerequisites
+The installation script supports two deployment modes:
+
+| Mode | Description |
+|------|-------------|
+| **K3s** | Deploys Trusted Compute components as Helm-managed workloads inside a K3s cluster |
+| **Docker** | Deploys the `kata-deploy` container directly via Docker Compose |
+
+---
+
+### Table of Contents
+
+| # | Section |
+|---|---------|
+| 1 | [Prerequisites](#1-prerequisites) |
+| 2 | [Download the Trusted Compute Package](#2-download-the-trusted-compute-package) |
+| 3 | [K3s Mode](#3-k3s-mode) |
+|   | &nbsp;&nbsp;3.1 [Installation](#31-installation) |
+|   | &nbsp;&nbsp;3.2 [Sample Trusted Workload Deployment](#32-sample-trusted-workload-deployment) |
+|   | &nbsp;&nbsp;3.3 [Uninstallation](#33-uninstallation) |
+| 4 | [Docker Mode](#4-docker-mode) |
+|   | &nbsp;&nbsp;4.1 [Installation](#41-installation) |
+|   | &nbsp;&nbsp;4.2 [Sample Container Check](#42-sample-container-check) |
+|   | &nbsp;&nbsp;4.3 [Uninstallation](#43-uninstallation) |
+
+---
+
+### 1. Prerequisites
 
 1. **Download Ubuntu 24.04 ISO:**
 	- Download the latest Ubuntu 24.04 ISO from the [official Ubuntu website](https://ubuntu.com/download/server).
@@ -9,80 +35,182 @@
 3. **Enable Secure Boot:**
 	- During installation, ensure Secure Boot is enabled in the BIOS/UEFI settings for enhanced security.
 
+> **Note:** Both K3s and Docker installations are mutually exclusive. If one is already installed, the script will prompt you to uninstall it first before proceeding with the other.
 
 ---
 
-### Installation Steps
+### 2. Download the Trusted Compute Package
 
-1. **Get the Latest Trusted Compute Package Tag and Download (using ORAS):**
+1. **Get the Latest Tag and Download (using ORAS):**
 	```bash
 	TAG=$(oras repo tags registry-rs.edgeorchestration.intel.com/edge-orch/trusted-compute/baremetal/trusted-compute-installation-package | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
 	oras pull registry-rs.edgeorchestration.intel.com/edge-orch/trusted-compute/baremetal/trusted-compute-installation-package:$TAG
 	```
-	- The first command fetches the latest version tag and stores it in the `TAG` variable.
-	- The second command downloads the `trusted-compute-installation-package.tgz` file using the latest tag.
-	- Ensure that you have ``oras`` available on your system or follow the instructions in the [oras documentation](https://oras.land/docs/installation) to install it.
+	- Ensure `oras` is available — see the [oras installation guide](https://oras.land/docs/installation).
 
-2. **Copy and Unzip Trusted Compute Package:**
-	- Transfer `trusted-compute-installation-package.tgz` to your edge node (using scp, USB, etc.), or use the file downloaded with `oras`.
-	- Extract the package:
+2. **Extract the Package:**
+	- Transfer `trusted-compute-installation-package.tgz` to your edge node (using scp, USB, etc.), then extract:
 	```bash
 	tar -xvf trusted-compute-installation-package.tgz
 	cd trusted-compute-installation-package
 	```
 
-3. **Install k3s:**
-	- Run the provided script to install k3s:
+---
+
+### 3. K3s Mode
+
+#### 3.1 Installation
+
+1. **Install K3s** (if not already installed):
+
+	Use the provided script:
 	```bash
 	sudo ./k3s/k3s.sh --install
 	```
+	Or install manually by following the [K3s Quick Start Guide](https://docs.k3s.io/quick-start).
 
-4. **Install Trusted Compute Extension:**
-	- Execute the installation script:
+2. **Run the installation script:**
+	```bash
+	sudo ./install.sh --k3s
+	```
+	Or run without arguments and select **K3s** in the interactive mode selector:
 	```bash
 	sudo ./install.sh
 	```
 
 ---
 
+#### 3.2 Sample Trusted Workload Deployment
 
-### Sample Trusted Workload Deployment
-To verify the Trusted Compute setup, deploy a sample nginx pod using Kata Containers.
+1. **Create the namespace:**
+	```bash
+	sudo kubectl create namespace nginx-test
+	```
 
-Create the namespace:
+2. **Deploy a sample nginx pod** (uses `runtimeClassName: kata-qemu`):
+	```bash
+	sudo kubectl -n nginx-test apply -f - <<'EOF'
+	apiVersion: v1
+	kind: Pod
+	metadata:
+	  name: nginx-default
+	  namespace: nginx-test
+	spec:
+	  runtimeClassName: kata-qemu
+	  containers:
+	  - name: nginx
+	    image: nginx:latest
+	EOF
+	```
 
-```bash
-sudo kubectl create namespace nginx-test
-```
+3. **Verify the deployment status:**
+	```bash
+	sudo kubectl get pods -n nginx-test
+	sudo kubectl describe pod nginx-default -n nginx-test
+	sudo kubectl logs nginx-default -n nginx-test
+	```
 
-Create the nginx pod using a heredoc (the pod uses runtimeClassName: kata-qemu):
+4. **Delete the pod and namespace after verification:**
+	```bash
+	sudo kubectl delete namespace nginx-test
+	```
 
-```bash
-sudo kubectl -n nginx-test apply -f - <<'EOF'
-apiVersion: v1
-kind: Pod
-metadata:
-  name: nginx-default
-  namespace: nginx-test
-spec:
-  runtimeClassName: kata-qemu
-  containers:
-  - name: nginx
-    image: nginx:latest
-EOF
-```
+---
 
-This will deploy an nginx server as a trusted workload. You can verify the deployment status with:
+#### 3.3 Uninstallation
 
-```bash
-sudo kubectl get pods -n nginx-test
-sudo kubectl describe pod nginx-default -n nginx-test
-sudo kubectl logs nginx-default -n nginx-test
-```
+1. **Run the uninstallation script:**
+	```bash
+	sudo ./uninstall.sh --k3s
+	```
+	Or run without arguments and select **K3s** in the interactive mode selector.
 
+---
 
-Delete the nginx pod and namespace after verification:
+### 4. Docker Mode
 
-```bash
-sudo kubectl delete namespace nginx-test
-```
+#### 4.1 Installation
+
+1. **Install Docker Engine** (if not already installed):
+
+	Follow the official guide for Ubuntu:
+	[https://docs.docker.com/engine/install/ubuntu/](https://docs.docker.com/engine/install/ubuntu/)
+
+2. **Install Docker Compose v2 plugin** (if not already installed):
+
+	Follow the official guide: [https://docs.docker.com/compose/install/linux/](https://docs.docker.com/compose/install/linux/)
+
+3. **Run the installation script:**
+	```bash
+	sudo ./install.sh --docker
+	```
+	Or run without arguments and select **Docker** in the interactive mode selector:
+	```bash
+	sudo ./install.sh
+	```
+
+---
+
+#### 4.2 Sample Container Check
+
+Once Trusted Compute is installed, run containers using the Kata Containers runtime for hardware-isolated Trusted Compute execution.
+
+1. **Run NGINX with the Kata runtime:**
+	```bash
+	docker run -d --name nginx-trusted-workload --runtime io.containerd.kata.v2 -p 80:80 nginx:latest
+	```
+
+2. **Verify the container is running:**
+	```bash
+	docker ps | grep nginx-trusted-workload
+	```
+
+3. **Verify it's using the Kata runtime:**
+	```bash
+	docker inspect nginx-trusted-workload --format '{{.HostConfig.Runtime}}'
+	```
+	Output should be: `io.containerd.kata.v2`
+
+4. **Stop and remove the container after verification:**
+	```bash
+	docker stop nginx-trusted-workload
+	docker rm nginx-trusted-workload
+	```
+
+**Alternatively, use Docker Compose to run NGINX with the Kata runtime:**
+
+5. **Create an `nginx.yaml` file with the following content:**
+	```yaml
+	services:
+	  nginx:
+	    image: nginx:latest
+	    container_name: nginx-trusted-workload
+	    ports:
+	      - "80:80"
+	    runtime: io.containerd.kata.v2
+	```
+
+6. **Start the container with Docker Compose:**
+	```bash
+	docker compose -f nginx.yaml up -d
+	```
+
+7. **Verify the container is running:**
+	```bash
+	docker ps -a | grep nginx-trusted-workload
+	```
+
+8. **Stop and remove the container:**
+	```bash
+	docker compose -f nginx.yaml down
+	```
+
+---
+
+#### 4.3 Uninstallation
+
+1. **Run the uninstallation script:**
+	```bash
+	sudo ./uninstall.sh --docker
+	```
+	Or run without arguments and select **Docker** in the interactive mode selector.

--- a/docs/trusted_compute_baremetal.md
+++ b/docs/trusted_compute_baremetal.md
@@ -1,8 +1,8 @@
 ## Trusted Compute Installation on Standalone Ubuntu Edge Node
 
-The installation script supports two deployment modes:
+The installation script supports two deployment options:
 
-| Mode | Description |
+| Option | Description |
 |------|-------------|
 | **K3s** | Deploys Trusted Compute components as Helm-managed workloads inside a K3s cluster |
 | **Docker** | Deploys the `kata-deploy` container directly via Docker Compose |
@@ -15,11 +15,11 @@ The installation script supports two deployment modes:
 |---|---------|
 | 1 | [Prerequisites](#1-prerequisites) |
 | 2 | [Download the Trusted Compute Package](#2-download-the-trusted-compute-package) |
-| 3 | [K3s Mode](#3-k3s-mode) |
+| 3 | [K3s Option](#3-k3s-option) |
 |   | &nbsp;&nbsp;3.1 [Installation](#31-installation) |
 |   | &nbsp;&nbsp;3.2 [Sample Trusted Workload Deployment](#32-sample-trusted-workload-deployment) |
 |   | &nbsp;&nbsp;3.3 [Uninstallation](#33-uninstallation) |
-| 4 | [Docker Mode](#4-docker-mode) |
+| 4 | [Docker Option](#4-docker-option) |
 |   | &nbsp;&nbsp;4.1 [Installation](#41-installation) |
 |   | &nbsp;&nbsp;4.2 [Sample Container Check](#42-sample-container-check) |
 |   | &nbsp;&nbsp;4.3 [Uninstallation](#43-uninstallation) |
@@ -57,7 +57,7 @@ The installation script supports two deployment modes:
 
 ---
 
-### 3. K3s Mode
+### 3. K3s Option
 
 #### 3.1 Installation
 
@@ -73,7 +73,7 @@ The installation script supports two deployment modes:
 	```bash
 	sudo ./install.sh --k3s
 	```
-	Or run without arguments and select **K3s** in the interactive mode selector:
+	Or run without arguments and select **K3s** in the interactive option selector:
 	```bash
 	sudo ./install.sh
 	```
@@ -123,11 +123,11 @@ The installation script supports two deployment modes:
 	```bash
 	sudo ./uninstall.sh --k3s
 	```
-	Or run without arguments and select **K3s** in the interactive mode selector.
+	Or run without arguments and select **K3s** in the interactive option selector.
 
 ---
 
-### 4. Docker Mode
+### 4. Docker Option
 
 #### 4.1 Installation
 
@@ -144,7 +144,7 @@ The installation script supports two deployment modes:
 	```bash
 	sudo ./install.sh --docker
 	```
-	Or run without arguments and select **Docker** in the interactive mode selector:
+	Or run without arguments and select **Docker** in the interactive option selector:
 	```bash
 	sudo ./install.sh
 	```
@@ -200,7 +200,12 @@ Once Trusted Compute is installed, run containers using the Kata Containers runt
 	docker ps -a | grep nginx-trusted-workload
 	```
 
-8. **Stop and remove the container:**
+8. **Check the container logs:**
+	```bash
+	docker logs nginx-trusted-workload
+	```
+
+9. **Stop and remove the container:**
 	```bash
 	docker compose -f nginx.yaml down
 	```
@@ -213,4 +218,4 @@ Once Trusted Compute is installed, run containers using the Kata Containers runt
 	```bash
 	sudo ./uninstall.sh --docker
 	```
-	Or run without arguments and select **Docker** in the interactive mode selector.
+	Or run without arguments and select **Docker** in the interactive option selector.

--- a/docs/trusted_compute_baremetal.md
+++ b/docs/trusted_compute_baremetal.md
@@ -5,7 +5,7 @@ The installation script supports two deployment options:
 | Option | Description |
 |------|-------------|
 | **K3s** | Deploys Trusted Compute components as Helm-managed workloads inside a K3s cluster |
-| **Docker** | Deploys the `kata-deploy` container directly via Docker Compose |
+| **Docker** | Deploys Trusted Compute Components directly via Docker Compose |
 
 ---
 
@@ -21,7 +21,7 @@ The installation script supports two deployment options:
 |   | &nbsp;&nbsp;3.3 [Uninstallation](#33-uninstallation) |
 | 4 | [Docker Option](#4-docker-option) |
 |   | &nbsp;&nbsp;4.1 [Installation](#41-installation) |
-|   | &nbsp;&nbsp;4.2 [Sample Container Check](#42-sample-container-check) |
+|   | &nbsp;&nbsp;4.2 [Sample Trusted Workload Deployment](#42-sample-trusted-workload-deployment) |
 |   | &nbsp;&nbsp;4.3 [Uninstallation](#43-uninstallation) |
 
 ---
@@ -151,16 +151,16 @@ The installation script supports two deployment options:
 
 ---
 
-#### 4.2 Sample Container Check
+#### 4.2 Sample Trusted Workload Deployment
 
-Once Trusted Compute is installed, run containers using the Kata Containers runtime for hardware-isolated Trusted Compute execution.
+Once Trusted Compute is installed, run workload by defining kata-runtime for hardware-isolated Trusted Compute execution.
 
-1. **Run NGINX with the Kata runtime:**
+1. **Run Workload with the Kata runtime:**
 	```bash
 	docker run -d --name nginx-test --runtime io.containerd.kata.v2 -p 80:80 nginx:latest
 	```
 
-2. **Verify the container is running:**
+2. **Verify the workload is running:**
 	```bash
 	docker ps | grep nginx-test
 	```
@@ -171,13 +171,13 @@ Once Trusted Compute is installed, run containers using the Kata Containers runt
 	```
 	Output should be: `io.containerd.kata.v2`
 
-4. **Stop and remove the container after verification:**
+4. **Stop and remove the workload after verification:**
 	```bash
 	docker stop nginx-test
 	docker rm nginx-test
 	```
 
-**Alternatively, use Docker Compose to run NGINX with the Kata runtime:**
+**Alternatively, use Docker Compose to run workload with the Kata runtime:**
 
 5. **Create an `nginx.yaml` file:**
 	```bash
@@ -192,22 +192,22 @@ Once Trusted Compute is installed, run containers using the Kata Containers runt
 	EOF
 	```
 
-6. **Start the container with Docker Compose:**
+6. **Start the workload with Docker Compose:**
 	```bash
 	docker compose -f nginx.yaml up -d
 	```
 
-7. **Verify the container is running:**
+7. **Verify the workload is running:**
 	```bash
 	docker ps -a | grep nginx-test
 	```
 
-8. **Check the container logs:**
+8. **Check the workload logs:**
 	```bash
 	docker logs nginx-test
 	```
 
-9. **Stop and remove the container:**
+9. **Stop and remove the workload:**
 	```bash
 	docker compose -f nginx.yaml down
 	```

--- a/docs/trusted_compute_baremetal.md
+++ b/docs/trusted_compute_baremetal.md
@@ -157,37 +157,39 @@ Once Trusted Compute is installed, run containers using the Kata Containers runt
 
 1. **Run NGINX with the Kata runtime:**
 	```bash
-	docker run -d --name nginx-trusted-workload --runtime io.containerd.kata.v2 -p 80:80 nginx:latest
+	docker run -d --name nginx-test --runtime io.containerd.kata.v2 -p 80:80 nginx:latest
 	```
 
 2. **Verify the container is running:**
 	```bash
-	docker ps | grep nginx-trusted-workload
+	docker ps | grep nginx-test
 	```
 
 3. **Verify it's using the Kata runtime:**
 	```bash
-	docker inspect nginx-trusted-workload --format '{{.HostConfig.Runtime}}'
+	docker inspect nginx-test --format '{{.HostConfig.Runtime}}'
 	```
 	Output should be: `io.containerd.kata.v2`
 
 4. **Stop and remove the container after verification:**
 	```bash
-	docker stop nginx-trusted-workload
-	docker rm nginx-trusted-workload
+	docker stop nginx-test
+	docker rm nginx-test
 	```
 
 **Alternatively, use Docker Compose to run NGINX with the Kata runtime:**
 
-5. **Create an `nginx.yaml` file with the following content:**
-	```yaml
+5. **Create an `nginx.yaml` file:**
+	```bash
+	cat > nginx.yaml <<'EOF'
 	services:
 	  nginx:
 	    image: nginx:latest
-	    container_name: nginx-trusted-workload
+	    container_name: nginx-test
 	    ports:
 	      - "80:80"
 	    runtime: io.containerd.kata.v2
+	EOF
 	```
 
 6. **Start the container with Docker Compose:**
@@ -197,12 +199,12 @@ Once Trusted Compute is installed, run containers using the Kata Containers runt
 
 7. **Verify the container is running:**
 	```bash
-	docker ps -a | grep nginx-trusted-workload
+	docker ps -a | grep nginx-test
 	```
 
 8. **Check the container logs:**
 	```bash
-	docker logs nginx-trusted-workload
+	docker logs nginx-test
 	```
 
 9. **Stop and remove the container:**


### PR DESCRIPTION
Adds Docker-based deployment support for the Trusted Compute baremetal “standalone” installation package, alongside the existing K3s-based flow.

Changes:

Extend baremetal/install.sh to support --docker mode (Docker Compose + imported kata-deploy image) and add interactive mode selection.
Introduce baremetal/uninstall.sh with K3s/Docker uninstall paths and interactive mode selection.
Package a Docker Compose definition for kata-deploy and update docs + packaging Makefile to include Docker artifacts.

Signe -off-by: Kumar, Anand <anand.kumar@intel.com>

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->

Fixes # (issue)

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->