### PR TITLE
Enable virtio_mem in kata-deploy build to fix kernel 6.12 memory hotp…

### DIFF
--- a/helm/attestation-verifier/charts/trustagent/values.yaml
+++ b/helm/attestation-verifier/charts/trustagent/values.yaml
@@ -57,7 +57,7 @@ config:
     /opt/kata/bin/qemu-system-x86_64
     /opt/kata/libexec/virtiofsd
     /opt/kata/share/defaults/kata-containers/configuration-qemu.toml
-    /opt/kata/share/kata-containers/vmlinuz-6.12.67-1.emt3
+    /opt/kata/share/kata-containers/vmlinuz-6.12.80-1.emt3
     /opt/kata/share/kata-containers/trusted-vm.img
     /opt/kata/share/kata-qemu/qemu/bios-256k.bin
     /opt/kata/share/kata-qemu/qemu/efi-virtio.rom

--- a/trusted-workload/kata-deploy/build-kata-deploy-image.sh
+++ b/trusted-workload/kata-deploy/build-kata-deploy-image.sh
@@ -110,9 +110,15 @@ echo "INFO: Enabling virtio_mem in configuration.toml for kernel 6.12 compatibil
 KATA_CONFIG_FILE="${KATA_CONFIG_DIR}/configuration.toml"
 if [ -f "${KATA_CONFIG_FILE}" ]; then
     sed -i 's/^enable_virtio_mem = false/enable_virtio_mem = true/' "${KATA_CONFIG_FILE}"
-    echo "INFO: virtio_mem enabled in ${KATA_CONFIG_FILE}"
+    if grep -q '^enable_virtio_mem = true$' "${KATA_CONFIG_FILE}"; then
+        echo "INFO: virtio_mem enabled in ${KATA_CONFIG_FILE}"
+    else
+        echo "ERROR: failed to enable virtio_mem in ${KATA_CONFIG_FILE}"
+        exit 1
+    fi
 else
-    echo "WARN: configuration.toml not found at ${KATA_CONFIG_FILE}"
+    echo "ERROR: configuration.toml not found at ${KATA_CONFIG_FILE}"
+    exit 1
 fi
 
 # Iterate over all files, directories, clean up unwanted files and directories and set permission and onwership

--- a/trusted-workload/kata-deploy/build-kata-deploy-image.sh
+++ b/trusted-workload/kata-deploy/build-kata-deploy-image.sh
@@ -37,6 +37,7 @@ KATA_ARTIFACT_FILE_NAME=$(basename "${KATA_ARTIFACT_RELEASE_URL##*/}")
 KATA_ARTIFACT_DIR="${KATA_ARTIFACT_FILE_NAME%.tar.zst}"
 KATA_ARTIFACT_NEW_NAME="kata-static.tar.zst"
 KATA_BOOT_COMPONENT_DIR="${KATA_ARTIFACT_DIR}/opt/kata/share/kata-containers"
+KATA_CONFIG_DIR="${KATA_ARTIFACT_DIR}/opt/kata/share/defaults/kata-containers"
 KATA_ARTIFACT_KERNEL_NAME="vmlinux.container"
 KATA_ARTIFACT_ROOTFS_NAME="kata-containers.img"
 
@@ -102,6 +103,17 @@ cp "${EDGE_MICROVISOR_SRC}/${EDGE_MICROVISOR_ROOTFS}" "${KATA_BOOT_COMPONENT_DIR
 echo "INFO: Change symlink to point to the new kernel and rootfs"
 ln -sf "${EDGE_MICROVISOR_KERNEL}" "${KATA_BOOT_COMPONENT_DIR}/${KATA_ARTIFACT_KERNEL_NAME}"
 ln -sf "${EDGE_MICROVISOR_ROOTFS}" "${KATA_BOOT_COMPONENT_DIR}/${KATA_ARTIFACT_ROOTFS_NAME}"
+
+# Enable virtio_mem in configuration.toml to fix kernel 6.12 memory hotplug issue
+# NOTE: This workaround is required for kernel 6.12.x due to broken memory probe mechanism
+echo "INFO: Enabling virtio_mem in configuration.toml for kernel 6.12 compatibility"
+KATA_CONFIG_FILE="${KATA_CONFIG_DIR}/configuration.toml"
+if [ -f "${KATA_CONFIG_FILE}" ]; then
+    sed -i 's/^enable_virtio_mem = false/enable_virtio_mem = true/' "${KATA_CONFIG_FILE}"
+    echo "INFO: virtio_mem enabled in ${KATA_CONFIG_FILE}"
+else
+    echo "WARN: configuration.toml not found at ${KATA_CONFIG_FILE}"
+fi
 
 # Iterate over all files, directories, clean up unwanted files and directories and set permission and onwership
 chmod 750 "${KATA_ARTIFACT_DIR}/opt/kata"

--- a/trusted-workload/kata-deploy/version.yaml
+++ b/trusted-workload/kata-deploy/version.yaml
@@ -13,9 +13,9 @@ kata-deploy:
 
 kernel:
     description: "Edge Microvisor kernel image"
-    name : "vmlinuz-6.12.67-1.emt3"
-    version: 6.12.67-1.emt3
-    config: "config-6.12.67-1.emt3"
+    name : "vmlinuz-6.12.80-1.emt3"
+    version: 6.12.80-1.emt3
+    config: "config-6.12.80-1.emt3"
 
 rootfs:
     description: "Edge Microvisor initrd image"


### PR DESCRIPTION
Enable virtio_mem in kata-deploy build to fix kernel 6.12 memory hotplug

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->

Fixes # (issue)

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->