### PR TITLE
ci: fix gomod Dependabot cooldown default-days to meet zizmor minimum (5->7)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,7 +50,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-      semver-patch-days: 3
     commit-message:
       prefix: "docker"
     open-pull-requests-limit: 5
@@ -69,7 +68,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-      semver-patch-days: 3
     commit-message:
       prefix: "docker"
     open-pull-requests-limit: 5
@@ -88,7 +86,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-      semver-patch-days: 3
     commit-message:
       prefix: "docker"
     open-pull-requests-limit: 5
@@ -107,7 +104,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-      semver-patch-days: 3
     commit-message:
       prefix: "docker"
     open-pull-requests-limit: 5
@@ -126,7 +122,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-      semver-patch-days: 3
     commit-message:
       prefix: "docker"
     open-pull-requests-limit: 5
@@ -145,7 +140,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-      semver-patch-days: 3
     commit-message:
       prefix: "docker"
     open-pull-requests-limit: 5
@@ -164,7 +158,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-      semver-patch-days: 3
     commit-message:
       prefix: "docker"
     open-pull-requests-limit: 5
@@ -183,7 +176,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-      semver-patch-days: 3
     commit-message:
       prefix: "docker"
     open-pull-requests-limit: 5
@@ -203,7 +195,6 @@ updates:
       interval: daily
     cooldown:
       default-days: 7
-      semver-patch-days: 3
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gha] "

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 5
+      default-days: 7
       semver-patch-days: 2
     commit-message:
       prefix: "deps"
@@ -29,7 +29,7 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 5
+      default-days: 7
       semver-patch-days: 2
     commit-message:
       prefix: "deps"


### PR DESCRIPTION
## Summary

Fixes insufficient cooldown.default-days for the two gomod updater entries in .github/dependabot.yml.

PR #475 added cooldown: to all 11 Dependabot updaters but used default-days: 5 for gomod entries. The zizmor dependabot-cooldown audit requires a minimum of **7 days** (the default threshold), so those entries still trigger the alert.

## Changes

- /attestation-verifier/src gomod: default-days: 5 ? 7
- /attestation-manager/src gomod: default-days: 5 ? 7

All other ecosystems already had default-days: 7.

## Related

Fixes zizmor/dependabot-cooldown alert #2804 (residual finding after #475)