### PR TITLE
fix: pin Go to 1.26.2 in tvm-agent build script and fix typo

### DIFF
--- a/trusted-vm/tvm-agent/tvm_agent_inside_container.sh
+++ b/trusted-vm/tvm-agent/tvm_agent_inside_container.sh
@@ -34,21 +34,14 @@ wget -q https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux
 chmod +x /usr/local/bin/yq
 
 # Install Go
-echo "INFO: Getting Go version from versions.yaml"
-GO_VERSION=$(yq e '.languages.golang.version' "${KATA_CONTAINER_DIR}/versions.yaml")
-if [ -z "${GO_VERSION}" ]; then
-    echo "ERROR: Failed to get Go version from versions.yaml"
-    GO_VERSION=1.25.9
-    echo "INFO: Installing default Go version : ${GO_VERSION}"
-else
-    echo "INFO: Installing Go version from versions.yaml : ${GO_VERSION}"
-fi
+GO_VERSION=1.26.2
+echo "INFO: Installing pinned Go version : ${GO_VERSION}"
 wget -q https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz || { echo "ERROR: Failed to download Go"; exit 1; }
 tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 
 # Install Rust
-echo "INFO: Getting Rust version from versoions.yaml"
+echo "INFO: Getting Rust version from versions.yaml"
 RUST_VERSION=$(yq e '.languages.rust.version' "${KATA_CONTAINER_DIR}/versions.yaml")
 if [ -z "${RUST_VERSION}" ]; then
     echo "ERROR: Failed to get Rust version from versions.yaml"


### PR DESCRIPTION
## Summary

Fixes a supply chain risk in `trusted-vm/tvm-agent/tvm_agent_inside_container.sh` where the Go version was read dynamically from `kata-containers/versions.yaml` (an upstream third-party project) at build time.

## Changes

### 1. Pin Go version explicitly (supply chain fix)

**Before:**
```bash
GO_VERSION=$(yq e '.languages.golang.version' "${KATA_CONTAINER_DIR}/versions.yaml")
if [ -z "${GO_VERSION}" ]; then
    GO_VERSION=1.25.9  # vulnerable fallback
fi
```

**After:**
```bash
GO_VERSION=1.26.2
```

This ensures:
- The compiler version is explicitly reviewed and updated via PR (same pattern as `attestation_verifier_inside_container.sh` after #474)
- No silent version changes when the kata-containers submodule is bumped
- Eliminates the vulnerable `1.25.9` fallback (CVE-2026-32280, CVE-2026-32281, CVE-2026-32283)

### 2. Fix typo in log message

`versoions.yaml` → `versions.yaml`

## Security Impact

Go `1.26.2` fixes CVE-2026-32280, CVE-2026-32281, CVE-2026-32283 compared to the previous fallback `1.25.9`.