### PR TITLE
fix: pin golang image by digest and add HEALTHCHECK NONE in attestation-verifier Dockerfiles

### DIFF
--- a/attestation-verifier/utils/tools/containers/init-wait/Dockerfile
+++ b/attestation-verifier/utils/tools/containers/init-wait/Dockerfile
@@ -14,4 +14,7 @@ RUN apt-get update && \
 # Add a user and switch to it
 USER 503
 
+# This container is an init container (runs to completion); health checking is not applicable.
+HEALTHCHECK NONE
+
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/attestation-verifier/utils/tools/containers/nats/Dockerfile
+++ b/attestation-verifier/utils/tools/containers/nats/Dockerfile
@@ -43,6 +43,9 @@ RUN set -eux; \
     mkdir -p /secrets && touch /.container-env && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# This container is an init/setup container (runs to completion); health checking is not applicable.
+HEALTHCHECK NONE
+
 # copy the cfssl binaries from builder stage (no Go runtime or sources remain)
 COPY --from=builder --chown=root:root --chmod=0755 /out/cfssl /usr/local/bin/cfssl
 COPY --from=builder --chown=root:root --chmod=0755 /out/cfssljson /usr/local/bin/cfssljson

--- a/attestation-verifier/utils/tools/containers/nats/Dockerfile
+++ b/attestation-verifier/utils/tools/containers/nats/Dockerfile
@@ -4,7 +4,7 @@
 # */
 
 # Multi-stage Dockerfile: build cfssl/cfssljson in a builder stage, copy only binaries into final image
-FROM golang:1.26.2-bookworm AS builder
+FROM golang:1.26.2-bookworm@sha256:47ce5636e9936b2c5cbf708925578ef386b4f8872aec74a67bd13a627d242b19 AS builder
 
 WORKDIR /src/cfssl
 


### PR DESCRIPTION
Addresses three open security alerts in attestation-verifier container Dockerfiles.

Scorecard alert #2815 - containerImage not pinned by hash:
- nats/Dockerfile: pinned golang:1.26.2-bookworm by sha256 digest

Trivy DS-0026 alerts #2063 and #2064 - No HEALTHCHECK defined:
- nats/Dockerfile: added HEALTHCHECK NONE
- init-wait/Dockerfile: added HEALTHCHECK NONE

Both are init/setup containers that run to completion. HEALTHCHECK NONE explicitly declares health checking as not applicable.