### PR TITLE
Update standalone doc: Add option to download specific version or latest

### DIFF
--- a/docs/trusted_compute_baremetal.md
+++ b/docs/trusted_compute_baremetal.md
@@ -41,11 +41,24 @@ The installation script supports two deployment options:
 
 ### 2. Download the Trusted Compute Package
 
-1. **Get the Latest Tag and Download (using ORAS):**
+1. **Download Trusted Compute Package (using ORAS):**
+
+	**Option 1: Download a Specific Version**
+	
+	If you want to download a specific version (e.g., 1.5.0):
+	```bash
+	VERSION=1.5.0
+	oras pull registry-rs.edgeorchestration.intel.com/edge-orch/trusted-compute/baremetal/trusted-compute-installation-package:$VERSION
+	```
+	
+	**Option 2: Download the Latest Version**
+	
+	If no specific version is required, download the latest:
 	```bash
 	TAG=$(oras repo tags registry-rs.edgeorchestration.intel.com/edge-orch/trusted-compute/baremetal/trusted-compute-installation-package | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
 	oras pull registry-rs.edgeorchestration.intel.com/edge-orch/trusted-compute/baremetal/trusted-compute-installation-package:$TAG
 	```
+	
 	- Ensure `oras` is available — see the [oras installation guide](https://oras.land/docs/installation).
 
 2. **Extract the Package:**


### PR DESCRIPTION
Description:

Updated the installation documentation to support downloading either a specific version (e.g., 1.5.0) or the latest version of the Trusted Compute package. This allows users to pin to specific versions for production deployments while maintaining the flexibility to use the latest release.


#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [ ] The changes in the PR have been built and tested
- [ ] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->

Fixes # (issue)

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->