### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge-attestation-manager.yml
+++ b/.github/workflows/post-merge-attestation-manager.yml
@@ -12,6 +12,8 @@ on:
       - release-*
     paths:
       - 'attestation-manager/**'
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-attestation-verifier.yml
+++ b/.github/workflows/post-merge-attestation-verifier.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - 'attestation-verifier/**'
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-baremetal.yml
+++ b/.github/workflows/post-merge-baremetal.yml
@@ -12,6 +12,8 @@ on:
       - release-*
     paths:
       - 'baremetal/**'
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-helm.yml
+++ b/.github/workflows/post-merge-helm.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - 'helm/**'
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-kata-deploy.yaml
+++ b/.github/workflows/post-merge-kata-deploy.yaml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - 'trusted-workload/kata-deploy/**'
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-trusted-vm.yml
+++ b/.github/workflows/post-merge-trusted-vm.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - 'trusted-vm/**'
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow configuration files to expand their triggering conditions. Specifically, it adds support for running the workflows when any Git tag is pushed, in addition to the existing branch and path filters. This ensures that the workflows are triggered on tag pushes, which can be important for release and deployment processes.

**Workflow trigger enhancements:**

* [`.github/workflows/post-merge-attestation-manager.yml`](diffhunk://#diff-7972572f7ac43fa5c3dbe16a42e1e839554bc078ced8fac42334596dda01665fR15-R16): Added a `tags` filter to trigger the workflow on any tag push.
* [`.github/workflows/post-merge-attestation-verifier.yml`](diffhunk://#diff-b8a895ef29be1e15d8d7156e3c4d3150918fa6bc9043919ef27b6094a7696420R14-R15): Added a `tags` filter to trigger the workflow on any tag push.
* [`.github/workflows/post-merge-baremetal.yml`](diffhunk://#diff-478256a61950b1c39a90d03626f8a1b65693bbc06ca7ee09364ee43e681b0d67R15-R16): Added a `tags` filter to trigger the workflow on any tag push.
* [`.github/workflows/post-merge-helm.yml`](diffhunk://#diff-64808e64bb86e2043922ef5a4d71c9ee99a7d4ce0847c88e0af8b691b28206eeR14-R15): Added a `tags` filter to trigger the workflow on any tag push.
* [`.github/workflows/post-merge-kata-deploy.yaml`](diffhunk://#diff-59d8d93ba7697cf2672fbb93a08c7eea4ce9321956da04368831670c0f735ae7R14-R15): Added a `tags` filter to trigger the workflow on any tag push.
* [`.github/workflows/post-merge-trusted-vm.yml`](diffhunk://#diff-dd31f38b71c3c6b3802bf0ee89e2146e945dec649f6d91324c170f896cc2de72R14-R15): Added a `tags` filter to trigger the workflow on any tag push.