### PR TITLE
Remove trigger on tag from post-merge workflows

### DIFF
--- a/.github/workflows/post-merge-attestation-manager.yml
+++ b/.github/workflows/post-merge-attestation-manager.yml
@@ -12,8 +12,6 @@ on:
       - release-*
     paths:
       - 'attestation-manager/**'
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-attestation-verifier.yml
+++ b/.github/workflows/post-merge-attestation-verifier.yml
@@ -11,8 +11,6 @@ on:
       - release-*
     paths:
       - 'attestation-verifier/**'
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-baremetal.yml
+++ b/.github/workflows/post-merge-baremetal.yml
@@ -12,8 +12,6 @@ on:
       - release-*
     paths:
       - 'baremetal/**'
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-helm.yml
+++ b/.github/workflows/post-merge-helm.yml
@@ -11,8 +11,6 @@ on:
       - release-*
     paths:
       - 'helm/**'
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-kata-deploy.yaml
+++ b/.github/workflows/post-merge-kata-deploy.yaml
@@ -11,8 +11,6 @@ on:
       - release-*
     paths:
       - 'trusted-workload/kata-deploy/**'
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-trusted-vm.yml
+++ b/.github/workflows/post-merge-trusted-vm.yml
@@ -11,8 +11,6 @@ on:
       - release-*
     paths:
       - 'trusted-vm/**'
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to simplify their trigger conditions. The main change is the removal of the `tags` trigger from multiple workflow configurations, meaning these workflows will no longer run automatically when a tag is pushed.

**Workflow trigger simplification:**

* Removed the `tags` trigger from `.github/workflows/post-merge-attestation-manager.yml`, so the workflow will not run on tag pushes anymore.
* Removed the `tags` trigger from `.github/workflows/post-merge-attestation-verifier.yml`, so the workflow will not run on tag pushes anymore.
* Removed the `tags` trigger from `.github/workflows/post-merge-baremetal.yml`, so the workflow will not run on tag pushes anymore.
* Removed the `tags` trigger from `.github/workflows/post-merge-helm.yml`, so the workflow will not run on tag pushes anymore.
* Removed the `tags` trigger from `.github/workflows/post-merge-kata-deploy.yaml`, so the workflow will not run on tag pushes anymore.
* Removed the `tags` trigger from `.github/workflows/post-merge-trusted-vm.yml`, so the workflow will not run on tag pushes anymore.