### PR TITLE
move values-kata-deploy-default.yaml to tc repo

### DIFF
--- a/baremetal/Makefile
+++ b/baremetal/Makefile
@@ -60,9 +60,12 @@ build:
 		-e 's/kata-deploy\.tgz/kata-deploy-$(KATA_DEPLOY_CHART_VERSION).tgz/g' \
 		"$$STAGEDIR/manifests/trusted-compute.yaml"
 
-	# Update the tag in the values file, then copy its content into the manifest
-	yq -i '.image.tag = "$(KATA_DEPLOY_VERSION)"' "$(KATA_DEPLOY_VALUES_FILE)"
-	yq -i '(select(.kind == "HelmChart" and .metadata.name == "kata-deploy").spec.valuesContent) = load_str("$(KATA_DEPLOY_VALUES_FILE)")' "$$STAGEDIR/manifests/trusted-compute.yaml"
+	# Update the tag in a staged copy of the values file, then copy its content into the manifest
+	KATA_DEPLOY_VALUES_STAGED="$$STAGEDIR/manifests/values-kata-deploy-default.yaml"
+	cp -a "$(KATA_DEPLOY_VALUES_FILE)" "$$KATA_DEPLOY_VALUES_STAGED"
+	yq -i '.image.tag = "$(KATA_DEPLOY_VERSION)"' "$$KATA_DEPLOY_VALUES_STAGED"
+	yq -i '(select(.kind == "HelmChart" and .metadata.name == "kata-deploy").spec.valuesContent) = load_str("'"$$KATA_DEPLOY_VALUES_STAGED"'")' "$$STAGEDIR/manifests/trusted-compute.yaml"
+	rm -f "$$KATA_DEPLOY_VALUES_STAGED"
 
 	cp -a "$(CURDIR)/config-v3.toml.tmpl" "$$STAGEDIR/containerd/config-v3.toml.tmpl"
 

--- a/baremetal/Makefile
+++ b/baremetal/Makefile
@@ -16,8 +16,7 @@ TRUSTED_WORKLOAD_VERSION         ?= $(shell cat ./../trusted-workload/VERSION)
 KATA_DEPLOY_VERSION              ?= $(shell cat ./../trusted-workload/kata-deploy/VERSION)
 KATA_DEPLOY_CHART_VERSION        ?= $(shell yq -r '."kata-containers".version' ./../trusted-workload/kata-deploy/version.yaml)
 KATA_DEPLOY_CHART_OCI            ?= oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy
-CLUSTER_EXTENSIONS_VERSION       ?= v1.6.0
-KATA_DEPLOY_VALUES_URL           ?= https://raw.githubusercontent.com/open-edge-platform/cluster-extensions/refs/tags/$(CLUSTER_EXTENSIONS_VERSION)/deployment-package/trusted-compute/values-kata-deploy-default.yaml
+KATA_DEPLOY_VALUES_FILE          ?= $(CURDIR)/values-kata-deploy-default.yaml
 
 all: 
 	@# Help: Runs build, lint, test stages
@@ -60,14 +59,9 @@ build:
 		-e 's/kata-deploy\.tgz/kata-deploy-$(KATA_DEPLOY_CHART_VERSION).tgz/g' \
 		"$$STAGEDIR/manifests/trusted-compute.yaml"
 
-	# Patch kata-deploy valuesContent from external values YAML
-	KATA_DEPLOY_VALUES_FILE="$$STAGEDIR/manifests/values-kata-deploy-default.yaml"
-	curl -fsSL "$(KATA_DEPLOY_VALUES_URL)" -o "$$KATA_DEPLOY_VALUES_FILE"
-	yq -i '(select(.kind == "HelmChart" and .metadata.name == "kata-deploy").spec.valuesContent) = load_str("'"$$KATA_DEPLOY_VALUES_FILE"'")' "$$STAGEDIR/manifests/trusted-compute.yaml"
-	rm -f "$$KATA_DEPLOY_VALUES_FILE"
-
-	# Update only the kata-deploy HelmChart valuesContent image tag to match KATA_DEPLOY_VERSION
-	yq -i '(select(.kind == "HelmChart" and .metadata.name == "kata-deploy").spec.valuesContent) |= sub("(?m)^([[:space:]]*tag: \")[^\"]*(\")$$"; "$${1}$(KATA_DEPLOY_VERSION)$${2}")' "$$STAGEDIR/manifests/trusted-compute.yaml"
+	# Update the tag in the values file, then copy its content into the manifest
+	yq -i '.image.tag = "$(KATA_DEPLOY_VERSION)"' "$(KATA_DEPLOY_VALUES_FILE)"
+	yq -i '(select(.kind == "HelmChart" and .metadata.name == "kata-deploy").spec.valuesContent) = load_str("$(KATA_DEPLOY_VALUES_FILE)")' "$$STAGEDIR/manifests/trusted-compute.yaml"
 
 	cp -a "$(CURDIR)/config-v3.toml.tmpl" "$$STAGEDIR/containerd/config-v3.toml.tmpl"
 

--- a/baremetal/values-kata-deploy-default.yaml
+++ b/baremetal/values-kata-deploy-default.yaml
@@ -3,7 +3,7 @@
 ---
 image:
   reference: registry-rs.edgeorchestration.intel.com/edge-orch/trusted-compute/kata-deploy
-  tag: "1.5.1-dev"
+  tag:
 k8sDistribution: "k3s" # k8s, k3s, rke2, k0s, microk8s
 debug: false
 snapshotter:

--- a/baremetal/values-kata-deploy-default.yaml
+++ b/baremetal/values-kata-deploy-default.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+---
+image:
+  reference: registry-rs.edgeorchestration.intel.com/edge-orch/trusted-compute/kata-deploy
+  tag: "1.5.1-dev"
+k8sDistribution: "k3s" # k8s, k3s, rke2, k0s, microk8s
+debug: false
+snapshotter:
+  setup: [] # ["nydus", "erofs"] or []
+# Shim configuration
+# By default (disableAll: false), all shims with enabled: ~ (null) are enabled.
+# Set disableAll: true to disable all shims, then explicitly enable specific ones:
+#   shims:
+#     disableAll: true
+#     qemu:
+#       enabled: true  # Only qemu is enabled
+shims:
+  disableAll: true
+  qemu:
+    enabled: true
+    supportedArches:
+      - amd64
+    allowedHypervisorAnnotations: [default_memory pcie_root_port hot_plug_vfio enable_virtio_mem]
+    containerd:
+      snapshotter: ""
+# Default shim per architecture
+defaultShim:
+  amd64: qemu
+runtimeClasses:
+  enabled: true
+  createDefault: false
+  defaultName: "kata"
+node-feature-discovery:
+  enabled: false
+imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Description
The values-kata-deploy-default.yaml file was previously sourced from the cluster-extension repository. Since cluster-extension is now read-only, this file has been moved into the trusted-compute repository to allow continued maintenance and updates.


#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->

Fixes # (issue)

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->