### PR TITLE
Update dependabot-auto-merge.yml

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -65,13 +65,6 @@ jobs:
   # Triggered when a Dependabot PR is actually merged into main: comments
   # "@dependabot rebase" on every remaining open Dependabot PR so each one
   # updates its branch, re-runs CI, and re-enters the auto-merge cycle.
-  rebase-remaining:
-    if: |
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.merged == true &&
-      github.event.pull_request.user.login == 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    steps:
       - name: Rebase remaining open Dependabot PRs
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
@@ -90,11 +83,15 @@ jobs:
               return;
             }
             for (const pr of remaining) {
-              core.info(`Requesting rebase for PR #${pr.number}: ${pr.title}`);
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                body: '@dependabot rebase',
-              });
+              core.info(`Updating branch for PR #${pr.number}: ${pr.title}`);
+              try {
+                await github.rest.pulls.updateBranch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                });
+                core.info(`Branch updated for PR #${pr.number}`);
+              } catch (error) {
+                core.warning(`Failed to update branch for PR #${pr.number}: ${error.message}`);
+              }
             }

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -62,9 +62,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Triggered when a Dependabot PR is actually merged into main: comments
-  # "@dependabot rebase" on every remaining open Dependabot PR so each one
-  # updates its branch, re-runs CI, and re-enters the auto-merge cycle.
+  # Triggered when a Dependabot PR is actually merged into main: calls the
+  # GitHub API to update the branch of every remaining open Dependabot PR so
+  # each one re-runs CI and re-enters the auto-merge cycle.
   rebase-remaining:
     if: |
       github.event_name == 'pull_request' &&

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -65,6 +65,13 @@ jobs:
   # Triggered when a Dependabot PR is actually merged into main: comments
   # "@dependabot rebase" on every remaining open Dependabot PR so each one
   # updates its branch, re-runs CI, and re-enters the auto-merge cycle.
+  rebase-remaining:
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
       - name: Rebase remaining open Dependabot PRs
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [ ] The changes in the PR have been built and tested
- [ ] Ready to merge

#### Description <!-- REQUIRED -->
## Description

Fixes the `rebase-remaining` job in the Dependabot auto-merge workflow.

### Problem

The `rebase-remaining` job was posting `@dependabot rebase` as a comment to trigger
branch updates on remaining open Dependabot PRs. GitHub has tightened Dependabot's
security policy so that these commands are now only accepted from human users with
push access — comments posted by `github-actions[bot]` are rejected with:

> Sorry, only users with push access can use that command.

A previous edit also accidentally dissolved the `rebase-remaining` job into the
`auto-merge` job, causing the step to run in the wrong event context
(`workflow_run` instead of `pull_request: closed`) and fail at runtime because
`context.payload.pull_request` is undefined during `workflow_run` events.

### Security
- Uses the short-lived, auto-generated `GITHUB_TOKEN` — no PATs or long-lived
  secrets are involved.
- Permissions are minimal and explicit (`contents: write`, `pull-requests: write`);
  no admin or org-level scopes are granted.
- The `rebase-remaining` job only fires when a `pull_request: closed` event is
  triggered by a merge **and** the PR author is `dependabot[bot]`, preventing
  any human-actor trigger.
- `updateBranch` is a strictly additive operation — it merges `main` into the
  Dependabot branch (identical to clicking "Update branch" on GitHub). It cannot
  push arbitrary code, overwrite history, or affect any branch outside the PR.
- Removes reliance on Dependabot's freeform text command parsing (`@dependabot rebase`),
  which is a less deterministic and less auditable code path.
- Failures are caught and logged as warnings rather than crashing the job, preventing
  any denial-of-service against the merge pipeline if a branch is already up to date
  or protected.

### Fix

- Replaced `github.rest.issues.createComment` (`@dependabot rebase`) with
  `github.rest.pulls.updateBranch`, which calls the GitHub REST API directly to
  update each Dependabot PR branch without requiring Dependabot command processing.
- Restored `rebase-remaining` as a separate job with its own `if:` condition so it
  only fires on `pull_request: closed` events for merged Dependabot PRs.
- Added `try/catch` around `updateBranch` to handle 422 responses gracefully
  (returned when a branch is already up to date).
- Updated job comments to reflect the new implementation.

### How it works

1. A Dependabot PR merges → `pull_request: closed` event fires
2. `rebase-remaining` job runs → calls `updateBranch` for each remaining open Dependabot PR
3. Branch update re-triggers CI on those PRs
4. When CI passes, `auto-merge` job fires and merges the next one → repeat

Fixes # (issue)

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->