### PR TITLE
Add job-level permissions to each job

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,21 +11,21 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   # Triggered when Virtual Integration passes: enables GitHub auto-merge on the PR.
   # GitHub will then merge it once all branch-protection requirements are met.
   auto-merge:
-    if: |
-      github.event_name == 'workflow_run' &&
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.actor.login == 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    steps:
+      permissions:
+        pull-requests: write   # for gh pr merge --auto and PR listing
+      if: |
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.actor.login == 'dependabot[bot]'
+      runs-on: ubuntu-latest
+      steps:
       - name: Resolve Dependabot PR number
         id: pr
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
@@ -66,6 +66,9 @@ jobs:
   # GitHub API to update the branch of every remaining open Dependabot PR so
   # each one re-runs CI and re-enters the auto-merge cycle.
   rebase-remaining:
+    permissions:
+      contents: write        # for updateBranch API call
+      pull-requests: read    # for listing open PRs
     if: |
       github.event_name == 'pull_request' &&
       github.event.pull_request.merged == true &&


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [ ] The changes in the PR have been built and tested
- [ ] Ready to merge

#### Description <!-- REQUIRED -->
## Description

Fixes the token-permissions code scanning finding reported on the
`dependabot-auto-merge.yml` workflow (line 15).

### Problem

The workflow had `contents: write` and `pull-requests: write` set at the
top-level `permissions:` block. This grants those permissions to **every job**
in the workflow, even jobs that do not need them — violating the principle of
least privilege and triggering the Scorecard `Token-Permissions` check:

> score is 0: topLevel 'contents' permission set to 'write'

### Fix

- Set top-level `permissions: {}` to deny all permissions by default.
- Add explicit job-level permissions scoped to the minimum each job requires:

| Job | `contents` | `pull-requests` | Reason |
|---|---|---|---|
| `auto-merge` | — | `write` | `gh pr merge --auto` sets the auto-merge flag; no content write needed |
| `rebase-remaining` | `write` | `read` | `updateBranch` modifies the branch; only reads PR list |

### Security

- No job can exceed its declared permissions, even if a future step is added
  that inadvertently relies on a broader token scope.
- `auto-merge` can no longer write to repository contents — it can only
  interact with pull requests.
- `rebase-remaining` can no longer modify pull request metadata — it can only
  read the PR list and update branches.
- Uses the short-lived, auto-generated `GITHUB_TOKEN` throughout — no PATs
  or long-lived secrets are involved.


#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->