### PR TITLE
standard remediation for zizmor's template-injection audit

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -23,7 +23,7 @@ jobs:
         github.event_name == 'workflow_run' &&
         github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.event == 'pull_request' &&
-        github.event.workflow_run.actor.login == 'dependabot[bot]'
+        github.event.workflow_run.actor.login == 'dependabot[bot]' &&
         github.event.workflow_run.head_repository.full_name == github.repository
       runs-on: ubuntu-latest
       steps:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -24,6 +24,7 @@ jobs:
         github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.event == 'pull_request' &&
         github.event.workflow_run.actor.login == 'dependabot[bot]'
+        github.event.workflow_run.head_repository.full_name == github.repository
       runs-on: ubuntu-latest
       steps:
       - name: Resolve Dependabot PR number

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -55,12 +55,13 @@ jobs:
 
       - name: Enable auto-merge
         run: |
-          gh pr merge "${{ steps.pr.outputs.number }}" \
+          gh pr merge "$PR_NUMBER" \
             --auto \
             --squash \
-            --repo "${{ github.repository }}"
+            --repo "$GITHUB_REPOSITORY"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
 
   # Triggered when a Dependabot PR is actually merged into main: calls the
   # GitHub API to update the branch of every remaining open Dependabot PR so


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [ ] The changes in the PR have been built and tested
- [ ] Ready to merge

#### Description <!-- REQUIRED -->
## Description

Addresses three security findings reported by zizmor on
`.github/workflows/dependabot-auto-merge.yml`.

**Fix:** 

#### 1. Pass dynamic values through environment variables, which the shell
reads as data — never as executable expressions.

```diff
- gh pr merge "${{ steps.pr.outputs.number }}" \
-   --repo "${{ github.repository }}"
+ gh pr merge "$PR_NUMBER" \
+   --repo "$GITHUB_REPOSITORY"
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+   PR_NUMBER: ${{ steps.pr.outputs.number }}
```

`$GITHUB_REPOSITORY` is a default GitHub Actions environment variable —
no template expansion needed at all.

#### 2. Insecure `workflow_run` Trigger (line 5) — `dangerous-triggers`

The `workflow_run` trigger always runs with the target repo's full secrets,
even when the triggering workflow was initiated from a fork PR. A malicious
fork could trigger "Virtual Integration", which would then cause this workflow
to run with secrets access.

**Fix:** Add a same-repository guard to the `auto-merge` job's `if:` condition:

```diff
     if: |
       github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.actor.login == 'dependabot[bot]'
+      github.event.workflow_run.actor.login == 'dependabot[bot]' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
```

This ensures the triggering workflow originated from `open-edge-platform/trusted-compute`
itself — not a fork. Fork-triggered runs are skipped entirely.


#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->