### PR TITLE
ci: suppress zizmor dangerous-triggers false positive on workflow_run

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,7 +3,7 @@
 name: Dependabot Auto-merge
 
 on:
-  workflow_run:
+  workflow_run: # zizmor: ignore[dangerous-triggers]
     workflows: ["Virtual Integration"]
     types: [completed]
   pull_request:


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [ ] The changes in the PR have been built and tested
- [ ] Ready to merge

#### Description <!-- REQUIRED -->
## Description

Suppresses the persistent zizmor `dangerous-triggers` finding on the
`workflow_run` trigger in `dependabot-auto-merge.yml`.

### Why this finding cannot be fully resolved

zizmor flags `workflow_run` as fundamentally insecure at the trigger-type
level, regardless of runtime mitigations. The finding persists even with all
practical controls in place.

### Mitigations already in place (from PR #527)

- Actor restricted to `dependabot[bot]` only
- Same-repo guard: `github.event.workflow_run.head_repository.full_name == github.repository`
  ensures the triggering workflow originated from this repo, not a fork
- No dynamic values interpolated into `run:` shell scripts
- Minimum job-level permissions (`pull-requests: write` only)

### Change

Adds `# zizmor: ignore[dangerous-triggers]` inline comment to document that
the risk has been reviewed, mitigations are in place, and the finding is
intentionally suppressed.

Fixes # (issue)

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->