### PR TITLE
ci: auto-request Copilot code review on human-raised PRs

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -12,7 +12,9 @@ permissions: {}
 
 jobs:
   request-copilot-review:
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    if: |
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -24,7 +24,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          requested="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/requested_reviewers" --jq '.users[].login')"
+          if printf '%s\n' "$requested" | grep -qx 'copilot-pull-request-reviewer[bot]'; then
+            echo "Copilot reviewer already requested; skipping."
+            exit 0
+          fi
           gh api \
-            repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/requested_reviewers \
+            "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/requested_reviewers" \
             --method POST \
             --field 'reviewers[]=copilot-pull-request-reviewer[bot]'

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+name: Request Copilot Review
+
+on:
+  pull_request:
+    types: [opened, reopened]
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  request-copilot-review:
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Request Copilot review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh api \
+            repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/requested_reviewers \
+            --method POST \
+            --field 'reviewers[]=copilot-pull-request-reviewer[bot]'


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [ ] The changes in the PR have been built and tested
- [ ] Ready to merge

#### Description <!-- REQUIRED -->
## Description

Adds a workflow that automatically requests Copilot as a reviewer on every
human-raised PR targeting `main`, eliminating the need to add it manually.

### Problem

GitHub Copilot code review is enabled for the org but requires manual
reviewer assignment on each PR. There is no repo-level auto-review setting
accessible without admin access.

### Fix

New workflow `.github/workflows/copilot-review.yml` triggers on
`pull_request: opened` and `reopened` events and calls the GitHub API to
request `copilot-pull-request-reviewer[bot]` as a reviewer automatically.

### Behaviour

| PR Author | Auto Copilot Review |
|---|---|
| Human (any) | ✅ Requested automatically |
| `dependabot[bot]` | ❌ Skipped (handled by auto-merge workflow) |

### Security

- `permissions: {}` at top level — no implicit permissions granted.
- `pull-requests: write` scoped to the job only — minimum required to
  request a reviewer.
- Dynamic values (`PR_NUMBER`) passed via environment variables — no
  template injection in `run:` blocks.
- Uses short-lived, auto-generated `GITHUB_TOKEN` — no PATs or long-lived
  secrets involved.

### Notes

- Triggers on `opened` and `reopened` only — not `synchronize` — so
  Copilot is requested once per PR lifecycle, not on every push.
- If the org admin enables the automatic Copilot review setting at the
  org level in the future, this workflow can be removed.

Fixes # (issue)

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->