### PR TITLE
Update copilot-review.yml

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -24,7 +24,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-            gh api \
-              "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/requested_reviewers" \
-              --method POST \
-              --field 'reviewers[]=copilot-pull-request-reviewer'
+          gh pr edit "$PR_NUMBER" \
+          --add-reviewer "copilot-pull-request-reviewer[bot]" \
+          --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -24,12 +24,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          requested="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/requested_reviewers" --jq '.users[].login')"
-          if printf '%s\n' "$requested" | grep -qx 'copilot-pull-request-reviewer[bot]'; then
-            echo "Copilot reviewer already requested; skipping."
-            exit 0
-          fi
-          gh api \
-            "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/requested_reviewers" \
-            --method POST \
-            --field 'reviewers[]=copilot-pull-request-reviewer[bot]'
+            gh api \
+              "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/requested_reviewers" \
+              --method POST \
+              --field 'reviewers[]=copilot-pull-request-reviewer'


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [ ] The changes in the PR have been built and tested
- [ ] Ready to merge

#### Description

Fixes the `copilot-review.yml` workflow which was silently failing to add Copilot as a reviewer on new PRs.

**Root cause — two bugs in the original implementation:**

1. **Wrong reviewer login**: The `[bot]` suffix (`copilot-pull-request-reviewer[bot]`) is a GitHub UI display convention only. The REST API silently ignores it and returns HTTP 200 without adding the reviewer.

2. **Broken idempotency check**: The pre-flight check queried `.users[].login` from the `requested_reviewers` endpoint. GitHub Apps never appear in `.users[]` (only human accounts do), so the check always evaluated to false — harmless but misleading.

**Fix:** Remove the broken idempotency check and use the correct API login `copilot-pull-request-reviewer` (without `[bot]`).

#### Any Newly Introduced Dependencies

None.

#### How Has This Been Tested?

Verified via action logs from PR #531 that the previous call returned HTTP 200 but left `requested_reviewers` unchanged. After this fix merges, PR #531 will be closed and reopened to confirm Copilot is correctly added to the reviewer list.